### PR TITLE
InventoryCache  - Fixing the performance bug

### DIFF
--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -62,6 +62,7 @@ namespace SMLHelper.V2
             KnownTechPatcher.Patch(harmony);
             BioReactorPatcher.Patch(harmony);
             OptionsPanelPatcher.Patch(harmony);
+            InventoryPatcher.Patch(harmony);
         }
     }
 }

--- a/SMLHelper/Patchers/InventoryPatcher.cs
+++ b/SMLHelper/Patchers/InventoryPatcher.cs
@@ -5,6 +5,8 @@
     using System.Reflection;
     using Harmony;
 
+    // This entire patcher is only here for performance reasons.
+    // This is not intended to be exposed by the public API.
     internal static class InventoryPatcher
     {
         private static Dictionary<Vector2int, bool> HasRoomCache = new Dictionary<Vector2int, bool>();
@@ -25,25 +27,26 @@
             MethodInfo HasRoomFor_Postfix_Method = patcherType.GetMethod("HasRoomFor_Postfix", BindingFlags.NonPublic | BindingFlags.Static);
             MethodInfo AddRemoveItem_Postfix_Method = patcherType.GetMethod("AddRemoveItem_Postfix", BindingFlags.NonPublic | BindingFlags.Static);
 
+            // Harmony methods
             harmony.Patch(
                 original: HasRoomFor_Pickupable_Method,
                 prefix: new HarmonyMethod(HasRoomFor_Pickupable_Prefix_Method),
-                postfix: new HarmonyMethod(HasRoomFor_Postfix_Method));
+                postfix: new HarmonyMethod(HasRoomFor_Postfix_Method)); // Both HasRoomFor methods share the same Postfix method
 
             harmony.Patch(
                 original: HasRoomFor_XY_Method,
                 prefix: new HarmonyMethod(HasRoomFor_XY_Prefix_Method),
-                postfix: new HarmonyMethod(HasRoomFor_Postfix_Method));
+                postfix: new HarmonyMethod(HasRoomFor_Postfix_Method)); // Both HasRoomFor methods share the same Postfix method
 
             harmony.Patch(
                 original: OnAddItem_Method,
-                prefix: null,
-                postfix: new HarmonyMethod(AddRemoveItem_Postfix_Method));
+                prefix: null, // No prefix call
+                postfix: new HarmonyMethod(AddRemoveItem_Postfix_Method)); // OnAddItem and OnRemoveItem share the same Postfix method
 
             harmony.Patch(
                 original: OnRemoveItem_Method,
-                prefix: null,
-                postfix: new HarmonyMethod(AddRemoveItem_Postfix_Method));
+                prefix: null, // No prefix call
+                postfix: new HarmonyMethod(AddRemoveItem_Postfix_Method)); // OnAddItem and OnRemoveItem share the same Postfix method
 
             Logger.Log($"InventoryPatcher is done.");
         }
@@ -51,31 +54,23 @@
         private static bool HasRoomFor_Pickupable_Prefix(Inventory __instance, Pickupable item, ref bool __result, ref Vector2int __state)
         {
             Vector2int itemSize = CraftData.GetItemSize(item.overrideTechUsed ? item.overrideTechType : item.GetTechType());
-            // Min of 1,1 for safety
-            itemSize.x = itemSize.x == 0 ? 1 : itemSize.x;
-            itemSize.y = itemSize.y == 0 ? 1 : itemSize.y;
 
-            if (HasRoomCache.TryGetValue(itemSize, out bool cachedResult))
-            {
-                // We've seen this size before.
-                __result = cachedResult;
-                return false; // Override the result and avoid the heavy calculation.
-            }
-
-            // Result wasn't in the cache. Let the original code run to make the calculation.
-            // We'll catch the result on the Postfix for the next frame.
-            __state = itemSize;
-            return true;
+            return CheckInventoryCache(itemSize, ref __result, ref __state);
         }
 
         private static bool HasRoomFor_XY_Prefix(Inventory __instance, int width, int height, ref bool __result, ref Vector2int __state)
         {
             var itemSize = new Vector2int(width, height);
-            // Min of 1,1 for safety
+
+            return CheckInventoryCache(itemSize, ref __result, ref __state);
+        }
+
+        private static bool CheckInventoryCache(Vector2int itemSize, ref bool __result, ref Vector2int __state)
+        {
+            // Minimum size should always be 1,1
             itemSize.x = itemSize.x == 0 ? 1 : itemSize.x;
             itemSize.y = itemSize.y == 0 ? 1 : itemSize.y;
 
-            Logger.Announce($"Prefix check for {itemSize.x},{itemSize.y}");
             if (HasRoomCache.TryGetValue(itemSize, out bool cachedResult))
             {
                 // We've seen this size before.
@@ -83,7 +78,7 @@
                 return false; // Override the result and avoid the heavy calculation.
             }
 
-            // Result wasn't in the cache. Let the original code run to make the calculation.
+            // The result wasn't in the cache. Let the original code run to make the calculation.
             // We'll catch the result on the Postfix for the next frame.
             __state = itemSize;
             return true;
@@ -92,12 +87,12 @@
         private static void HasRoomFor_Postfix(Inventory __instance, bool __result, ref Vector2int __state)
         {
             // We should only enter this method if the Prefix didn't have a cached value to use.
-
+            // Catch the result and map it to the size provided by the Prefix.
             if (__state.x == 0 || __state.y == 0)
                 return; // Somehow, this can still happen. Don't store 0,0 in the cache. It breaks the game.
 
-            // The large calculation won't have to be done again until the inventory changes again.
-            // Why wasn't something like this in the base game to begin with???
+            // The large calculation won't have to be done again until something is added or removed from the inventory.
+            // How does the base game get away with calculating this mess on every frame???
             HasRoomCache.Add(__state, __result);
         }
 

--- a/SMLHelper/Patchers/InventoryPatcher.cs
+++ b/SMLHelper/Patchers/InventoryPatcher.cs
@@ -1,0 +1,110 @@
+﻿namespace SMLHelper.V2.Patchers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using Harmony;
+
+    internal static class InventoryPatcher
+    {
+        private static Dictionary<Vector2int, bool> HasRoomCache = new Dictionary<Vector2int, bool>();
+
+        internal static void Patch(HarmonyInstance harmony)
+        {
+            // Original methods
+            Type inventoryType = typeof(Inventory);
+            MethodInfo HasRoomFor_Pickupable_Method = inventoryType.GetMethod("HasRoomFor", new Type[] { typeof(Pickupable) });
+            MethodInfo HasRoomFor_XY_Method = inventoryType.GetMethod("HasRoomFor", new Type[] { typeof(int), typeof(int) });
+            MethodInfo OnAddItem_Method = inventoryType.GetMethod("OnAddItem", BindingFlags.NonPublic | BindingFlags.Instance);
+            MethodInfo OnRemoveItem_Method = inventoryType.GetMethod("OnRemoveItem", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Patcher methods
+            Type patcherType = typeof(InventoryPatcher);
+            MethodInfo HasRoomFor_Pickupable_Prefix_Method = patcherType.GetMethod("HasRoomFor_Pickupable_Prefix", BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo HasRoomFor_XY_Prefix_Method = patcherType.GetMethod("HasRoomFor_XY_Prefix", BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo HasRoomFor_Postfix_Method = patcherType.GetMethod("HasRoomFor_Postfix", BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo AddRemoveItem_Postfix_Method = patcherType.GetMethod("AddRemoveItem_Postfix", BindingFlags.NonPublic | BindingFlags.Static);
+
+            harmony.Patch(
+                original: HasRoomFor_Pickupable_Method,
+                prefix: new HarmonyMethod(HasRoomFor_Pickupable_Prefix_Method),
+                postfix: new HarmonyMethod(HasRoomFor_Postfix_Method));
+
+            harmony.Patch(
+                original: HasRoomFor_XY_Method,
+                prefix: new HarmonyMethod(HasRoomFor_XY_Prefix_Method),
+                postfix: new HarmonyMethod(HasRoomFor_Postfix_Method));
+
+            harmony.Patch(
+                original: OnAddItem_Method,
+                prefix: null,
+                postfix: new HarmonyMethod(AddRemoveItem_Postfix_Method));
+
+            harmony.Patch(
+                original: OnRemoveItem_Method,
+                prefix: null,
+                postfix: new HarmonyMethod(AddRemoveItem_Postfix_Method));
+
+            Logger.Log($"InventoryPatcher is done.");
+        }
+
+        private static bool HasRoomFor_Pickupable_Prefix(Inventory __instance, Pickupable item, ref bool __result, ref Vector2int __state)
+        {
+            Vector2int itemSize = CraftData.GetItemSize(item.overrideTechUsed ? item.overrideTechType : item.GetTechType());
+            // Min of 1,1 for safety
+            itemSize.x = itemSize.x == 0 ? 1 : itemSize.x;
+            itemSize.y = itemSize.y == 0 ? 1 : itemSize.y;
+
+            if (HasRoomCache.TryGetValue(itemSize, out bool cachedResult))
+            {
+                // We've seen this size before.
+                __result = cachedResult;
+                return false; // Override the result and avoid the heavy calculation.
+            }
+
+            // Result wasn't in the cache. Let the original code run to make the calculation.
+            // We'll catch the result on the Postfix for the next frame.
+            __state = itemSize;
+            return true;
+        }
+
+        private static bool HasRoomFor_XY_Prefix(Inventory __instance, int width, int height, ref bool __result, ref Vector2int __state)
+        {
+            var itemSize = new Vector2int(width, height);
+            // Min of 1,1 for safety
+            itemSize.x = itemSize.x == 0 ? 1 : itemSize.x;
+            itemSize.y = itemSize.y == 0 ? 1 : itemSize.y;
+
+            Logger.Announce($"Prefix check for {itemSize.x},{itemSize.y}");
+            if (HasRoomCache.TryGetValue(itemSize, out bool cachedResult))
+            {
+                // We've seen this size before.
+                __result = cachedResult;
+                return false; // Override the result and avoid the heavy calculation.
+            }
+
+            // Result wasn't in the cache. Let the original code run to make the calculation.
+            // We'll catch the result on the Postfix for the next frame.
+            __state = itemSize;
+            return true;
+        }
+
+        private static void HasRoomFor_Postfix(Inventory __instance, bool __result, ref Vector2int __state)
+        {
+            // We should only enter this method if the Prefix didn't have a cached value to use.
+
+            if (__state.x == 0 || __state.y == 0)
+                return; // Somehow, this can still happen. Don't store 0,0 in the cache. It breaks the game.
+
+            // The large calculation won't have to be done again until the inventory changes again.
+            // Why wasn't something like this in the base game to begin with???
+            HasRoomCache.Add(__state, __result);
+        }
+
+        private static void AddRemoveItem_Postfix()
+        {
+            // Items in the inventory have changed. Clear out the cache.
+            HasRoomCache.Clear();
+        }
+    }
+}

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Legacy\Patchers\LanguagePatcher.cs" />
     <Compile Include="Options\ModOptions.cs" />
     <Compile Include="MonoBehaviours\Fixer.cs" />
+    <Compile Include="Patchers\InventoryPatcher.cs" />
     <Compile Include="Patchers\OptionsPanelPatcher.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Legacy\Patchers\TechTypePatcher.cs" />


### PR DESCRIPTION
- Patches in a new caching system for the Player Inventory
  - This FINALLY fixes the major performance hit that would come from performing the "HasRoomFor" calculation.
  - This calculation gets exponentially slower as more and more items are added to the inventory, eventually tanking the FPS of the game as each frame has to wait longer and longer for the calculatino to finish.
  - The issue is only really noticeable with SMLHelper, likely given that it patches the Enums themselves
  - With this cache in place, we no longer repeat the calculation on every frame.
  - Instead, the result is cached in one frame and then reused until the the contents of the inventory changes.
