### PR TITLE
Language overrides

### DIFF
--- a/SMLHelper/Assets/ModPrefab.cs
+++ b/SMLHelper/Assets/ModPrefab.cs
@@ -25,6 +25,8 @@
         internal static bool TryGetFromFileName(string classId, out ModPrefab prefab) => FileNameDictionary.TryGetValue(classId, out prefab);
         internal static bool TryGetFromClassId(string classId, out ModPrefab prefab) => ClassIdDictionary.TryGetValue(classId, out prefab);
 
+        internal readonly string ModName;
+
         /// <summary>
         /// The class identifier used for the <see cref="PrefabIdentifier" /> component whenever applicable.
         /// </summary>
@@ -54,6 +56,8 @@
             ClassID = classId;
             PrefabFileName = prefabFileName;
             TechType = techType;
+
+            ModName = this.GetType().Assembly.GetName().Name;
         }
 
         internal GameObject GetGameObjectInternal()

--- a/SMLHelper/Assets/Spawnable.cs
+++ b/SMLHelper/Assets/Spawnable.cs
@@ -1,6 +1,7 @@
 ﻿namespace SMLHelper.V2.Assets
 {
     using System;
+    using System.Reflection;
     using Handlers;
 
     /// <summary>
@@ -98,7 +99,7 @@
 
             // Because invocation order isn't guaranteed by event handlers,
             // we make sure the TechType is patched first before anything else that might require it.
-            this.TechType = TechTypeHandler.AddTechType(this.ClassID, this.FriendlyName, this.Description, false);
+            this.TechType = TechTypeHandler.AddTechType(ModName, this.ClassID, this.FriendlyName, this.Description, false);
 
             CorePatchEvents.Invoke();
 

--- a/SMLHelper/Crafting/ModCraftTreeFamily.cs
+++ b/SMLHelper/Crafting/ModCraftTreeFamily.cs
@@ -309,8 +309,8 @@
             {
                 if (node.action == TreeAction.Expand)
                 {
-                    var thing = (ModCraftTreeLinkingNode)tab;
                     ModCraftTreeTab tab = root.AddTabNode(node.id);
+                    var thing = (ModCraftTreeLinkingNode)tab;
                     CreateFromExistingTree(node, ref thing);
                 }
 

--- a/SMLHelper/Crafting/ModCraftTreeFamily.cs
+++ b/SMLHelper/Crafting/ModCraftTreeFamily.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using Assets;
     using Patchers;
     using UnityEngine;
@@ -29,7 +30,7 @@
         public readonly TechType TechType;
 
         /// <summary>
-        /// The name ID for this tab node.        
+        /// The name ID for this tab node.
         /// </summary>
         public readonly string Name;
 
@@ -107,7 +108,9 @@
         /// <returns>A new tab node linked to the root node and ready to use.</returns>
         public ModCraftTreeTab AddTabNode(string nameID, string displayText, Atlas.Sprite sprite)
         {
-            var tabNode = new ModCraftTreeTab(nameID, displayText, sprite);
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            var tabNode = new ModCraftTreeTab(modName, nameID, displayText, sprite);
             tabNode.LinkToParent(this);
 
             ChildNodes.Add(tabNode);
@@ -124,7 +127,9 @@
         /// <returns>A new tab node linked to the root node and ready to use.</returns>
         public ModCraftTreeTab AddTabNode(string nameID, string displayText, Sprite sprite)
         {
-            var tabNode = new ModCraftTreeTab(nameID, displayText, sprite);
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            var tabNode = new ModCraftTreeTab(modName, nameID, displayText, sprite);
             tabNode.LinkToParent(this);
 
             ChildNodes.Add(tabNode);
@@ -139,7 +144,9 @@
         /// <returns>A new tab node linked to the root node and ready to use.</returns>
         public ModCraftTreeTab AddTabNode(string nameID)
         {
-            var tabNode = new ModCraftTreeTab(nameID);
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            var tabNode = new ModCraftTreeTab(modName, nameID);
             tabNode.LinkToParent(this);
 
             ChildNodes.Add(tabNode);
@@ -368,27 +375,31 @@
         private readonly Atlas.Sprite Asprite;
         private readonly Sprite Usprite;
         private readonly bool IsExistingTab;
+        private readonly string ModName;
 
-        internal ModCraftTreeTab(string nameID, string displayText, Atlas.Sprite sprite)
+        internal ModCraftTreeTab(string modName, string nameID, string displayText, Atlas.Sprite sprite)
             : base(nameID, TreeAction.Expand, TechType.None)
         {
             DisplayText = displayText;
             Asprite = sprite;
             Usprite = null;
+            ModName = modName;
         }
 
-        internal ModCraftTreeTab(string nameID, string displayText, Sprite sprite)
+        internal ModCraftTreeTab(string modName, string nameID, string displayText, Sprite sprite)
             : base(nameID, TreeAction.Expand, TechType.None)
         {
             DisplayText = displayText;
             Asprite = null;
             Usprite = sprite;
+            ModName = modName;
         }
 
-        internal ModCraftTreeTab(string nameID)
+        internal ModCraftTreeTab(string modName, string nameID)
             : base(nameID, TreeAction.Expand, TechType.None)
         {
             IsExistingTab = true;
+            ModName = modName;
         }
 
         internal override void LinkToParent(ModCraftTreeLinkingNode parent)
@@ -397,9 +408,7 @@
 
             if (IsExistingTab) return;
 
-            string tabLanguageID = $"{SchemeAsString}Menu_{Name}";
-
-            LanguagePatcher.customLines[tabLanguageID] = DisplayText;
+            LanguagePatcher.AddCustomLanguageLine(ModName, $"{base.SchemeAsString}Menu_{Name}", DisplayText);
 
             string spriteID = $"{SchemeAsString}_{Name}";
 

--- a/SMLHelper/Crafting/NodeFamily.cs
+++ b/SMLHelper/Crafting/NodeFamily.cs
@@ -31,14 +31,14 @@
         internal string DisplayName { get; set; }
         internal string Name { get; set; }
 
-        internal TabNode(string[] path, CraftTree.Type scheme, Atlas.Sprite sprite, string name, string displayName) : base(path, scheme)
+        internal TabNode(string[] path, CraftTree.Type scheme, Atlas.Sprite sprite, string modName, string name, string displayName) : base(path, scheme)
         {
             Sprite = sprite;
             DisplayName = displayName;
             Name = name;
 
-            ModSprite.Add(new ModSprite(SpriteManager.Group.Category, $"{Scheme.ToString()}_{Name}", Sprite));
-            LanguagePatcher.customLines[$"{Scheme.ToString()}Menu_{Name}"] = DisplayName;
+            ModSprite.Add(new ModSprite(SpriteManager.Group.Category, $"{Scheme.ToString()}_{Name}", Sprite));            
+            LanguagePatcher.AddCustomLanguageLine(modName, $"{Scheme.ToString()}Menu_{Name}", DisplayName);
         }
     }
 }

--- a/SMLHelper/Crafting/NodeFamily.cs
+++ b/SMLHelper/Crafting/NodeFamily.cs
@@ -37,7 +37,7 @@
             DisplayName = displayName;
             Name = name;
 
-            ModSprite.Add(new ModSprite(SpriteManager.Group.Category, $"{Scheme.ToString()}_{Name}", Sprite));            
+            ModSprite.Add(new ModSprite(SpriteManager.Group.Category, $"{Scheme.ToString()}_{Name}", Sprite));
             LanguagePatcher.AddCustomLanguageLine(modName, $"{Scheme.ToString()}Menu_{Name}", DisplayName);
         }
     }

--- a/SMLHelper/Handlers/CraftTreeHandler.cs
+++ b/SMLHelper/Handlers/CraftTreeHandler.cs
@@ -4,6 +4,7 @@
     using Patchers;
     using Utility;
     using UnityEngine.Assertions;
+    using System.Reflection;
 
     /// <summary>
     /// A handler class for creating and editing of crafting trees.
@@ -87,7 +88,9 @@
         public static void AddTabNode(CraftTree.Type craftTree, string name, string displayName, Atlas.Sprite sprite)
         {
             Assert.IsTrue(craftTree <= CraftTree.Type.Rocket, $"{nameof(AddTabNode)} is intended for use only with standard crafting trees, not custom ones.");
-            CraftTreePatcher.TabNodes.Add(new TabNode(new string[0], craftTree, sprite, name, displayName));
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            CraftTreePatcher.TabNodes.Add(new TabNode(new string[0], craftTree, sprite, modName, name, displayName));
         }
 
         /// <summary>
@@ -101,7 +104,9 @@
         public static void AddTabNode(CraftTree.Type craftTree, string name, string displayName, UnityEngine.Sprite sprite)
         {
             Assert.IsTrue(craftTree <= CraftTree.Type.Rocket, $"{nameof(AddTabNode)} is intended for use only with standard crafting trees, not custom ones.");
-            CraftTreePatcher.TabNodes.Add(new TabNode(new string[0], craftTree, new Atlas.Sprite(sprite), name, displayName));
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            CraftTreePatcher.TabNodes.Add(new TabNode(new string[0], craftTree, new Atlas.Sprite(sprite), modName, name, displayName));
         }
 
         /// <summary>
@@ -120,7 +125,9 @@
         public static void AddTabNode(CraftTree.Type craftTree, string name, string displayName, Atlas.Sprite sprite, params string[] stepsToTab)
         {
             Assert.IsTrue(craftTree <= CraftTree.Type.Rocket, $"{nameof(AddTabNode)} is intended for use only with standard crafting trees, not custom ones.");
-            CraftTreePatcher.TabNodes.Add(new TabNode(stepsToTab, craftTree, sprite, name, displayName));
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            CraftTreePatcher.TabNodes.Add(new TabNode(stepsToTab, craftTree, sprite, modName, name, displayName));
         }
 
         /// <summary>
@@ -139,7 +146,9 @@
         public static void AddTabNode(CraftTree.Type craftTree, string name, string displayName, UnityEngine.Sprite sprite, params string[] stepsToTab)
         {
             Assert.IsTrue(craftTree <= CraftTree.Type.Rocket, $"{nameof(AddTabNode)} is intended for use only with standard crafting trees, not custom ones.");
-            CraftTreePatcher.TabNodes.Add(new TabNode(stepsToTab, craftTree, new Atlas.Sprite(sprite), name, displayName));
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            CraftTreePatcher.TabNodes.Add(new TabNode(stepsToTab, craftTree, new Atlas.Sprite(sprite), modName, name, displayName));
         }
 
         /// <summary>

--- a/SMLHelper/Handlers/LanguageHandler.cs
+++ b/SMLHelper/Handlers/LanguageHandler.cs
@@ -1,5 +1,6 @@
 ﻿namespace SMLHelper.V2.Handlers
 {
+    using System.Reflection;
     using Patchers;
 
     public class LanguageHandler
@@ -11,16 +12,22 @@
         /// <param name="text">The actual text related to the entry.</param>
         public static void SetLanguageLine(string lineId, string text)
         {
-            LanguagePatcher.customLines[lineId] = text;
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            LanguagePatcher.AddCustomLanguageLine(modName, lineId, text);
         }
-        
+
         /// <summary>
         /// Allows you to set the display name of a specific <see cref="TechType"/>.
         /// </summary>
         /// <param name="techType">The <see cref="TechType"/> whose display name that is to be changed.</param>
         /// <param name="text">The new display name for the chosen <see cref="TechType"/>.</param>
         public static void SetTechTypeName(TechType techType, string text)
-            => SetLanguageLine(techType.AsString(), text);
+        {
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            LanguagePatcher.AddCustomLanguageLine(modName, techType.AsString(), text);
+        }
 
         /// <summary>
         /// Allows you to set the tooltip of a specific <see cref="TechType"/>.
@@ -28,6 +35,10 @@
         /// <param name="techType">The <see cref="TechType"/> whose tooltip that is to be changed.</param>
         /// <param name="text">The new tooltip for the chosen <see cref="TechType"/>.</param>
         public static void SetTechTypeTooltip(TechType techType, string text)
-            => SetLanguageLine($"Tooltip_{techType.AsString()}", text);
+        {
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            LanguagePatcher.AddCustomLanguageLine(modName, $"Tooltip_{techType.AsString()}", text);
+        }
     }
 }

--- a/SMLHelper/Handlers/TechTypeHandler.cs
+++ b/SMLHelper/Handlers/TechTypeHandler.cs
@@ -24,12 +24,19 @@
         /// <returns>The new <see cref="TechType"/> that is created.</returns>
         public static TechType AddTechType(string internalName, string displayName, string tooltip, bool unlockAtStart = true)
         {
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+            return AddTechType(modName, internalName, displayName, tooltip, unlockAtStart);
+        }
+
+        internal static TechType AddTechType(string modName, string internalName, string displayName, string tooltip, bool unlockAtStart = true)
+        {
             // Register the TechType.
             var techType = TechTypePatcher.AddTechType(internalName);
 
             // Register Language lines.
-            LanguagePatcher.customLines[internalName] = displayName;
-            LanguagePatcher.customLines["Tooltip_" + internalName] = tooltip;
+            LanguagePatcher.AddCustomLanguageLine(modName, internalName, displayName);
+            LanguagePatcher.AddCustomLanguageLine(modName, "Tooltip_" + internalName, tooltip);
+
             var valueToString = CachedEnumString_valueToString.GetValue(TooltipFactory.techTypeTooltipStrings) as Dictionary<TechType, string>;
             valueToString[techType] = "Tooltip_" + internalName;
 
@@ -52,8 +59,10 @@
         /// <returns>The new <see cref="TechType"/> that is created.</returns>
         public static TechType AddTechType(string internalName, string displayName, string tooltip, Atlas.Sprite sprite, bool unlockAtStart = true)
         {
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
             // Register the TechType using overload.
-            var techType = AddTechType(internalName, displayName, tooltip, unlockAtStart);
+            var techType = AddTechType(modName, internalName, displayName, tooltip, unlockAtStart);
 
             // Register the Sprite
             if(sprite != null)
@@ -74,8 +83,10 @@
         /// <returns>The new <see cref="TechType"/> that is created.</returns>
         public static TechType AddTechType(string internalName, string displayName, string tooltip, UnityEngine.Sprite sprite, bool unlockAtStart = true)
         {
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
             // Register the TechType using overload.
-            var techType = AddTechType(internalName, displayName, tooltip, unlockAtStart);
+            var techType = AddTechType(modName, internalName, displayName, tooltip, unlockAtStart);
 
             // Register the Sprite
             if (sprite != null)

--- a/SMLHelper/Legacy/CustomCraftTab.cs
+++ b/SMLHelper/Legacy/CustomCraftTab.cs
@@ -1,4 +1,5 @@
-﻿using SMLHelper.V2.Patchers;
+﻿using System.Reflection;
+using SMLHelper.V2.Patchers;
 
 namespace SMLHelper
 {
@@ -33,7 +34,9 @@ namespace SMLHelper
             Scheme = scheme;
             Sprite = new CustomSprite(SpriteManager.Group.Category, SpriteId, sprite);
 
-            LanguagePatcher.customLines[LanguageId] = name;
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            LanguagePatcher.AddCustomLanguageLine(modName, LanguageId, name);
             CustomSpriteHandler.customSprites.Add(Sprite);
         }
         

--- a/SMLHelper/Legacy/CustomCraftTreeFamily.cs
+++ b/SMLHelper/Legacy/CustomCraftTreeFamily.cs
@@ -20,9 +20,11 @@
         protected readonly TechType TechType;
         protected readonly string Name;
 
+        protected readonly string ModName;
+
         protected CustomCraftTreeLinkingNode Parent = null;
 
-        protected virtual CraftTree.Type Scheme => this.Parent.Scheme;        
+        protected virtual CraftTree.Type Scheme => this.Parent.Scheme;
         protected virtual string SchemeAsString => this.Parent.SchemeAsString;
 
         protected CustomCraftTreeNode(string name, TreeAction action, TechType techType)
@@ -188,7 +190,8 @@
 
             string tabLanguageID = $"{SchemeAsString}Menu_{Name}";
 
-            LanguagePatcher.customLines[tabLanguageID] = DisplayText;
+            // Legacy Support
+            LanguagePatcher.AddCustomLanguageLine("SMLHelper", tabLanguageID, DisplayText);
 
             string spriteID = $"{SchemeAsString}_{Name}";
 

--- a/SMLHelper/Legacy/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Legacy/Patchers/CraftTreePatcher.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using CraftTreePatcher2 = SMLHelper.V2.Patchers.CraftTreePatcher;
-    using V2.Handlers;
     using V2.Crafting;
     using System.Linq;
 
@@ -26,7 +25,7 @@
 
         internal static void Patch()
         {
-            customTabs.ForEach(x => CraftTreePatcher2.TabNodes.Add(new TabNode(x.Path.Split('/'), x.Scheme, x.Sprite.Sprite, "SMLHelper", System.IO.Path.GetFileName(x.Path), x.Name)));
+            customTabs.ForEach(x => CraftTreePatcher2.TabNodes.Add(new TabNode(x.Path.Split('/'), x.Scheme, x.Sprite.Sprite, "SMLHelper"/*Legacy Support*/, System.IO.Path.GetFileName(x.Path), x.Name)));
             customNodes.ForEach(x => CraftTreePatcher2.CraftingNodes.Add(new CraftingNode(x.Path.Split('/').Take(x.Path.Split('/').Length - 1).ToArray(), x.Scheme, x.TechType)));
             customCraftNodes.ForEach(x => CraftTreePatcher2.CraftingNodes.Add(new CraftingNode(x.Key.Split('/').Take(x.Key.Split('/').Length - 1).ToArray(), CraftTree.Type.Fabricator, x.Value)));
             nodesToRemove.ForEach(x => CraftTreePatcher2.NodesToRemove.Add(new Node(x.Path.Split('/'), x.Scheme)));

--- a/SMLHelper/Legacy/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Legacy/Patchers/CraftTreePatcher.cs
@@ -26,7 +26,7 @@
 
         internal static void Patch()
         {
-            customTabs.ForEach(x => CraftTreePatcher2.TabNodes.Add(new TabNode(x.Path.Split('/'), x.Scheme, x.Sprite.Sprite, System.IO.Path.GetFileName(x.Path), x.Name)));
+            customTabs.ForEach(x => CraftTreePatcher2.TabNodes.Add(new TabNode(x.Path.Split('/'), x.Scheme, x.Sprite.Sprite, "SMLHelper", System.IO.Path.GetFileName(x.Path), x.Name)));
             customNodes.ForEach(x => CraftTreePatcher2.CraftingNodes.Add(new CraftingNode(x.Path.Split('/').Take(x.Path.Split('/').Length - 1).ToArray(), x.Scheme, x.TechType)));
             customCraftNodes.ForEach(x => CraftTreePatcher2.CraftingNodes.Add(new CraftingNode(x.Key.Split('/').Take(x.Key.Split('/').Length - 1).ToArray(), CraftTree.Type.Fabricator, x.Value)));
             nodesToRemove.ForEach(x => CraftTreePatcher2.NodesToRemove.Add(new Node(x.Path.Split('/'), x.Scheme)));

--- a/SMLHelper/Legacy/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Legacy/Patchers/LanguagePatcher.cs
@@ -11,7 +11,8 @@ namespace SMLHelper.Patchers
 
         internal static void Patch()
         {
-            customLines.ForEach(x => LanguagePatcher2.customLines.Add(x.Key, x.Value));
+            foreach (KeyValuePair<string, string> kvPair in customLines)
+                LanguagePatcher2.AddCustomLanguageLine("SMLHelperLegacy", kvPair.Key, kvPair.Value);
 
             V2.Logger.Log("Old LanguagePatcher is done.");
         }

--- a/SMLHelper/Legacy/Patchers/TechTypePatcher.cs
+++ b/SMLHelper/Legacy/Patchers/TechTypePatcher.cs
@@ -1,4 +1,5 @@
-﻿using SMLHelper.V2.Handlers;
+﻿using System.Reflection;
+using SMLHelper.V2.Handlers;
 
 namespace SMLHelper.Patchers
 {
@@ -8,13 +9,17 @@ namespace SMLHelper.Patchers
         [System.Obsolete("Use SMLHelper.V2 instead.")]
         public static TechType AddTechType(string name, string languageName, string languageTooltip)
         {
-            return TechTypeHandler.AddTechType(name, languageName, languageTooltip);
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            return TechTypeHandler.AddTechType(modName, name, languageName, languageTooltip);
         }
 
         [System.Obsolete("Use SMLHelper.V2 instead.")]
         public static TechType AddTechType(string name, string languageName, string languageTooltip, bool unlockOnGameStart)
         {
-            return TechTypeHandler.AddTechType(name, languageName, languageTooltip, unlockOnGameStart);
+            string modName = Assembly.GetCallingAssembly().GetName().Name;
+
+            return TechTypeHandler.AddTechType(modName, name, languageName, languageTooltip, unlockOnGameStart);
         }
     }
 }

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -1,20 +1,29 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
-    using Harmony;
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Reflection;
+    using System.Text;
+    using Harmony;
 
     internal class LanguagePatcher
     {
+        private const string LanguageDir = "./QMods/Modding Helper/Language";
+        private const string LanguageOrigDir = LanguageDir + "/Originals";
+        private const string LanguageOverDir = LanguageDir + "/Overrides";
+
+        private static readonly Dictionary<string, Dictionary<string, string>> OriginalCustomLines = new Dictionary<string, Dictionary<string, string>>();
+
         public static Dictionary<string, string> customLines = new Dictionary<string, string>();
+
         private static Type languageType = typeof(Language);
 
         internal static void Postfix(ref Language __instance)
         {
-            var stringsField = languageType.GetField("strings", BindingFlags.NonPublic | BindingFlags.Instance);
+            FieldInfo stringsField = languageType.GetField("strings", BindingFlags.NonPublic | BindingFlags.Instance);
             var strings = stringsField.GetValue(__instance) as Dictionary<string, string>;
-            foreach (var a in customLines)
+            foreach (KeyValuePair<string, string> a in customLines)
             {
                 strings[a.Key] = a.Value;
             }
@@ -22,11 +31,95 @@
 
         internal static void Patch(HarmonyInstance harmony)
         {
-            var method = languageType.GetMethod("LoadLanguageFile", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (!Directory.Exists(LanguageDir))
+                Directory.CreateDirectory(LanguageDir);
 
-            harmony.Patch(method, null,
-                new HarmonyMethod(typeof(LanguagePatcher).GetMethod("Postfix", BindingFlags.Static | BindingFlags.NonPublic)));
+            WriteOriginalCustomLines();
+
+            ReadOverrideCustomLines();
+
+            harmony.Patch(
+                original: languageType.GetMethod("LoadLanguageFile", BindingFlags.NonPublic | BindingFlags.Instance),
+                prefix: null,
+                postfix: new HarmonyMethod(typeof(LanguagePatcher).GetMethod("Postfix", BindingFlags.Static | BindingFlags.NonPublic)));
+
             Logger.Log("LanguagePatcher is done.");
+        }
+
+        private static void WriteOriginalCustomLines()
+        {
+            Logger.Log("Writing original language files.");
+
+            if (!Directory.Exists(LanguageOrigDir))
+                Directory.CreateDirectory(LanguageOrigDir);
+
+            foreach (string modKey in OriginalCustomLines.Keys)
+            {
+                var text = new StringBuilder();
+                foreach (string langLineKey in OriginalCustomLines[modKey].Keys)
+                {
+                    string value = OriginalCustomLines[modKey][langLineKey];
+                    text.AppendLine($"{langLineKey}:'{value}'");
+                }
+
+                File.WriteAllText($"{LanguageOrigDir}/{modKey}.txt", text.ToString());
+            }
+        }
+
+        private static void ReadOverrideCustomLines()
+        {
+            Logger.Log("Reading override language files.");
+
+            if (!Directory.Exists(LanguageOverDir))
+                Directory.CreateDirectory(LanguageOverDir);
+
+            string[] files = Directory.GetFiles(LanguageOverDir);
+
+            foreach (string file in files)
+            {
+                string modName = Path.GetFileName(file).Replace(".txt", string.Empty);
+
+                if (!OriginalCustomLines.ContainsKey(modName))
+                    continue; // Not for a mod we know about
+
+                string[] languageLines = File.ReadAllLines(file);
+
+                Dictionary<string, string> originalLines = OriginalCustomLines[modName];
+
+                int overridesApplied = 0;
+
+                foreach (string line in languageLines)
+                {
+                    if (string.IsNullOrEmpty(line))
+                        continue; // Skip empty lines
+
+                    string[] split = line.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+
+                    if (split.Length != 2)
+                        continue; // Not correctly formatted
+
+                    string key = split[0];
+
+                    if (!originalLines.ContainsKey(key))
+                        continue; // Skip keys we don't recognize.
+
+                    string value = split[1];
+
+                    customLines[key] = value.Trim('\'');
+                    overridesApplied++;
+                }
+
+                Logger.Log($"Applied {overridesApplied} language overrides to mod {modName}.");
+            }
+        }
+
+        internal static void AddCustomLanguageLine(string modAssemblyName, string lineId, string text)
+        {
+            if (!OriginalCustomLines.ContainsKey(modAssemblyName))
+                OriginalCustomLines.Add(modAssemblyName, new Dictionary<string, string>());
+
+            OriginalCustomLines[modAssemblyName][lineId] = text;
+            customLines[lineId] = text;
         }
     }
 }

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -78,7 +78,7 @@
                 text.AppendLine($"{langLineKey}{KeyValueSeparator}{TextDelimiter}{value}{TextDelimiter}");
             }
 
-            File.WriteAllText($"{LanguageOrigDir}/{modKey}.txt", text.ToString());
+            File.WriteAllText($"{LanguageOrigDir}/{modKey}.txt", text.ToString(), Encoding.UTF8);
         }
 
         private static void ReadOverrideCustomLines()
@@ -103,7 +103,7 @@
                 if (!originalCustomLines.ContainsKey(modName))
                     continue; // Not for a mod we know about
 
-                string[] languageLines = File.ReadAllLines(file);
+                string[] languageLines = File.ReadAllLines(file, Encoding.UTF8);
 
                 Dictionary<string, string> originalLines = originalCustomLines[modName];
 
@@ -147,7 +147,7 @@
             if (!File.Exists(fileName))
                 return true; // File not found
 
-            string[] lines = File.ReadAllLines(fileName);
+            string[] lines = File.ReadAllLines(fileName, Encoding.UTF8);
 
             if (lines.Length != modCustomLines.Count)
                 return true; // Difference in line count


### PR DESCRIPTION
From Feature Request #69 
## User-Driven Language Overrides
> Enables end users to provide their own language files which will override the corresponding custom language entries created by mods.
> This makes for a simple way for users to translate in-game mod text into their native language without the need to involve the mod author.
> Mod authors will also be able to share translation files and instruct users on where to drop these files.

Functions as so:
1. The `LanguagePatcher` collects all custom language strings as normal but now also organized them by mod.
2. When the `Patch` method if finally called, this data is saved to files for users to examine.
  a. A txt file for each mod's language entries will be saved to `/Modding Helper/Language/Originals/`
  b. If the corresponding txt file already exists and matches the collected data, it will not be re-written.
  c. Each file is named after the mod assembly, making them easy to identify.
3. Users can copy these original language files into `/Modding Helper/Language/Overrides/` and replace the original text provided by the mod for their own text.
4. `LanguagePatcher` will look for these files during its `Patch` method call.
  a. The file is parsed and each line verified to make sure it is correctly formatted and actually belongs to the mod in the file name.
  b. When a match is found, the user provided text will be used in place of the text provided by the mod.

