### PR TITLE
SafeLegacyTechData

### DIFF
--- a/SMLHelper/Legacy/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Legacy/Patchers/CraftDataPatcher.cs
@@ -1,7 +1,5 @@
-﻿using Harmony;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using CraftDataPatcher2 = SMLHelper.V2.Patchers.CraftDataPatcher;
 
@@ -42,7 +40,7 @@ namespace SMLHelper.Patchers
 
         internal static void Patch()
         {
-            customTechData.ForEach(x => CraftDataPatcher2.CustomTechData.Add(x.Key, x.Value));
+            customTechData.ForEach(x => CraftDataPatcher2.AddToCustomTechData(x.Key, x.Value));
 
             customHarvestOutputList.ForEach(x => CraftDataPatcher2.CustomHarvestOutputList.Add(x.Key, x.Value));
             customHarvestTypeList.ForEach(x => CraftDataPatcher2.CustomHarvestTypeList.Add(x.Key, x.Value));

--- a/SMLHelper/mod.json
+++ b/SMLHelper/mod.json
@@ -2,7 +2,7 @@
   "Id": "SMLHelper",
   "DisplayName": "Modding Helper (SMLHelper)",
   "Author": "AHK1221 & PrimeSonic & AlexejheroYTB",
-  "Version": "2.1.0",
+  "Version": "2.1.1",
   "Enable": true,
   "Priority": "Last",
   "AssemblyName": "SMLHelper.dll",


### PR DESCRIPTION
 - Legacy CraftDataPatcher sends entries to V2.CraftDataPatcher via the safer [AddToCustomTechData](https://github.com/SMLHelper/SMLHelper/blob/2.Dev/SMLHelper/Patchers/CraftDataPatcher.cs#L94) method
- This prevents duplicate key exceptions
