### PR TITLE
CraftDataDupChecks - Check for duplicate keys

### DIFF
--- a/SMLHelper.Tests/Properties/AssemblyInfo.cs
+++ b/SMLHelper.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SMLHelper.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SMLHelper.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("ebc4aaf3-a13b-427e-bf99-3ae23edeb4b8")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SMLHelper.Tests/SMLHelper.Tests.csproj
+++ b/SMLHelper.Tests/SMLHelper.Tests.csproj
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EBC4AAF3-A13B-427E-BF99-3AE23EDEB4B8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SMLHelper.Tests</RootNamespace>
+    <AssemblyName>SMLHelper.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="UnityEngine">
+      <HintPath>..\Dependencies\UnityEngine.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SelfCheckingDictionaryTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SMLHelper\SMLHelper.csproj">
+      <Project>{418502dd-372d-4ef9-8021-b262552dfede}</Project>
+      <Name>SMLHelper</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/SMLHelper.Tests/SelfCheckingDictionaryTests.cs
+++ b/SMLHelper.Tests/SelfCheckingDictionaryTests.cs
@@ -66,10 +66,10 @@
                 { TechType.AcidMushroom, 3 } // Dup
             };
 
-            Assert.IsFalse(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsFalse(testDictionary.UniqueEntries.ContainsKey(TechType.AcidMushroom));
             Assert.IsTrue(testDictionary.DuplicatesDiscarded.ContainsKey(TechType.AcidMushroom));
             Assert.AreEqual(1, testDictionary.DuplicatesDiscarded.Count);
-            Assert.AreEqual(2, testDictionary.DuplicatesDiscarded[TechType.AcidMushroom]); // Discarded twice
+            Assert.AreEqual(3, testDictionary.DuplicatesDiscarded[TechType.AcidMushroom]); // Discarded all three
 
             Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
             Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
@@ -89,10 +89,10 @@
                 { TechType.AcidMushroom, 3 } // Dup
             };
 
-            Assert.IsFalse(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsFalse(testDictionary.UniqueEntries.ContainsKey(TechType.AcidMushroom));
             Assert.IsTrue(testDictionary.DuplicatesDiscarded.ContainsKey(TechType.AcidMushroom));            
             Assert.AreEqual(1, testDictionary.DuplicatesDiscarded.Count);
-            Assert.AreEqual(2, testDictionary.DuplicatesDiscarded[TechType.AcidMushroom]); // Discarded twice
+            Assert.AreEqual(3, testDictionary.DuplicatesDiscarded[TechType.AcidMushroom]); // Discarded all three
 
             Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
             Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
@@ -120,8 +120,8 @@
             Assert.AreEqual(1, testDictionary.Count); // Count goes down as dup is removed
             Assert.AreEqual(1, testDictionary.DuplicatesDiscarded.Count);
             Assert.IsTrue(testDictionary.DuplicatesDiscarded.ContainsKey(TechType.Accumulator));
-            Assert.IsFalse(testDictionary.ContainsKey(TechType.Accumulator));
-            Assert.AreEqual(1, testDictionary.DuplicatesDiscarded[TechType.Accumulator]); // Discarded once
+            Assert.IsFalse(testDictionary.UniqueEntries.ContainsKey(TechType.Accumulator));
+            Assert.AreEqual(2, testDictionary.DuplicatesDiscarded[TechType.Accumulator]); // Discarded twice
         }
 
         // ----

--- a/SMLHelper.Tests/SelfCheckingDictionaryTests.cs
+++ b/SMLHelper.Tests/SelfCheckingDictionaryTests.cs
@@ -1,0 +1,124 @@
+﻿namespace SMLHelper.Tests
+{
+    using NUnit.Framework;
+    using SMLHelper.V2.Patchers;
+
+    [TestFixture]
+    internal class SelfCheckingDictionaryTests
+    {
+        [Test]
+        public void Add_WhenUnique_AllAdded()
+        {
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test")
+            {
+                { TechType.AcidMushroom, 1 },
+                { TechType.AcidMushroomSpore, 2 },
+                { TechType.WhiteMushroom, 3 },
+                { TechType.WhiteMushroomSpore, 4 },
+                { TechType.PinkMushroom, 5 },
+                { TechType.PinkMushroomSpore, 6 },
+            };
+
+            Assert.AreEqual(6, testDictionary.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroomSpore));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroomSpore));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroomSpore));
+        }
+
+        [Test]
+        public void Add_WhenUnique_AllAdded_Alt()
+        {
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test", TechTypeExtensions.sTechTypeComparer)
+            {
+                { TechType.AcidMushroom, 1 },
+                { TechType.AcidMushroomSpore, 2 },
+                { TechType.WhiteMushroom, 3 },
+                { TechType.WhiteMushroomSpore, 4 },
+                { TechType.PinkMushroom, 5 },
+                { TechType.PinkMushroomSpore, 6 },
+            };
+
+            Assert.AreEqual(6, testDictionary.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroomSpore));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroomSpore));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroomSpore));
+        }
+
+        [Test]
+        public void Add_WhenDupEncountered_AutoRemoved_NotVisible()
+        {
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test")
+            {
+                { TechType.AcidMushroom, 1 },
+                { TechType.WhiteMushroom, 1 },
+                { TechType.AcidMushroom, 2 }, // Dup
+                { TechType.PinkMushroom, 2 },
+                { TechType.AcidMushroom, 3 } // Dup
+            };
+
+            Assert.IsFalse(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsTrue(testDictionary.DuplicatesFound.Contains(TechType.AcidMushroom));
+            Assert.AreEqual(1, testDictionary.DuplicatesFound.Count);
+
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
+
+            Assert.AreEqual(2, testDictionary.Count);
+        }
+
+        [Test]
+        public void Add_WhenDupEncountered_AutoRemoved_NotVisible_Alt()
+        {
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test", TechTypeExtensions.sTechTypeComparer)
+            {
+                { TechType.AcidMushroom, 1 },
+                { TechType.WhiteMushroom, 1 },
+                { TechType.AcidMushroom, 2 }, // Dup
+                { TechType.PinkMushroom, 2 },
+                { TechType.AcidMushroom, 3 } // Dup
+            };
+
+            Assert.IsFalse(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsTrue(testDictionary.DuplicatesFound.Contains(TechType.AcidMushroom));
+            Assert.AreEqual(1, testDictionary.DuplicatesFound.Count);
+
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
+
+            Assert.AreEqual(2, testDictionary.Count);
+        }
+
+        [Test]
+        public void Add_StepByStep_DupsRemoved()
+        {
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test");
+
+            Assert.AreEqual(0, testDictionary.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+
+            testDictionary.Add(TechType.Accumulator, 0);
+            Assert.AreEqual(1, testDictionary.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+
+            testDictionary.Add(TechType.AdvancedWiringKit, 0);
+            Assert.AreEqual(2, testDictionary.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+
+            testDictionary.Add(TechType.Accumulator, 0); // Dup
+            Assert.AreEqual(1, testDictionary.Count); // Count goes down as dup is removed
+            Assert.AreEqual(1, testDictionary.DuplicatesFound.Count);
+            Assert.IsTrue(testDictionary.DuplicatesFound.Contains(TechType.Accumulator));
+            Assert.IsFalse(testDictionary.ContainsKey(TechType.Accumulator));
+        }
+    }
+}

--- a/SMLHelper.Tests/SelfCheckingDictionaryTests.cs
+++ b/SMLHelper.Tests/SelfCheckingDictionaryTests.cs
@@ -20,7 +20,7 @@
             };
 
             Assert.AreEqual(6, testDictionary.Count);
-            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesDiscarded.Count);
 
             Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroom));
             Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroomSpore));
@@ -31,7 +31,7 @@
         }
 
         [Test]
-        public void Add_WhenUnique_AllAdded_Alt()
+        public void Add_WhenUnique_AllAdded_AltComparer()
         {
             var testDictionary = new SelfCheckingDictionary<TechType, int>("Test", TechTypeExtensions.sTechTypeComparer)
             {
@@ -44,7 +44,7 @@
             };
 
             Assert.AreEqual(6, testDictionary.Count);
-            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesDiscarded.Count);
 
             Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroom));
             Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroomSpore));
@@ -67,8 +67,9 @@
             };
 
             Assert.IsFalse(testDictionary.ContainsKey(TechType.AcidMushroom));
-            Assert.IsTrue(testDictionary.DuplicatesFound.Contains(TechType.AcidMushroom));
-            Assert.AreEqual(1, testDictionary.DuplicatesFound.Count);
+            Assert.IsTrue(testDictionary.DuplicatesDiscarded.ContainsKey(TechType.AcidMushroom));
+            Assert.AreEqual(1, testDictionary.DuplicatesDiscarded.Count);
+            Assert.AreEqual(2, testDictionary.DuplicatesDiscarded[TechType.AcidMushroom]); // Discarded twice
 
             Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
             Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
@@ -77,7 +78,7 @@
         }
 
         [Test]
-        public void Add_WhenDupEncountered_AutoRemoved_NotVisible_Alt()
+        public void Add_WhenDupEncountered_AutoRemoved_NotVisible_AltComparer()
         {
             var testDictionary = new SelfCheckingDictionary<TechType, int>("Test", TechTypeExtensions.sTechTypeComparer)
             {
@@ -89,8 +90,9 @@
             };
 
             Assert.IsFalse(testDictionary.ContainsKey(TechType.AcidMushroom));
-            Assert.IsTrue(testDictionary.DuplicatesFound.Contains(TechType.AcidMushroom));
-            Assert.AreEqual(1, testDictionary.DuplicatesFound.Count);
+            Assert.IsTrue(testDictionary.DuplicatesDiscarded.ContainsKey(TechType.AcidMushroom));            
+            Assert.AreEqual(1, testDictionary.DuplicatesDiscarded.Count);
+            Assert.AreEqual(2, testDictionary.DuplicatesDiscarded[TechType.AcidMushroom]); // Discarded twice
 
             Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
             Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
@@ -104,21 +106,124 @@
             var testDictionary = new SelfCheckingDictionary<TechType, int>("Test");
 
             Assert.AreEqual(0, testDictionary.Count);
-            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesDiscarded.Count);
 
             testDictionary.Add(TechType.Accumulator, 0);
             Assert.AreEqual(1, testDictionary.Count);
-            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesDiscarded.Count);
 
             testDictionary.Add(TechType.AdvancedWiringKit, 0);
             Assert.AreEqual(2, testDictionary.Count);
-            Assert.AreEqual(0, testDictionary.DuplicatesFound.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesDiscarded.Count);
 
             testDictionary.Add(TechType.Accumulator, 0); // Dup
             Assert.AreEqual(1, testDictionary.Count); // Count goes down as dup is removed
-            Assert.AreEqual(1, testDictionary.DuplicatesFound.Count);
-            Assert.IsTrue(testDictionary.DuplicatesFound.Contains(TechType.Accumulator));
+            Assert.AreEqual(1, testDictionary.DuplicatesDiscarded.Count);
+            Assert.IsTrue(testDictionary.DuplicatesDiscarded.ContainsKey(TechType.Accumulator));
             Assert.IsFalse(testDictionary.ContainsKey(TechType.Accumulator));
+            Assert.AreEqual(1, testDictionary.DuplicatesDiscarded[TechType.Accumulator]); // Discarded once
+        }
+
+        // ----
+
+        [Test]
+        public void SetByIndexer_WhenUnique_AllAdded()
+        {
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test")
+            {
+                [TechType.AcidMushroom] = 1,
+                [TechType.AcidMushroomSpore] = 2,
+                [TechType.WhiteMushroom] = 3,
+                [TechType.WhiteMushroomSpore] = 4,
+                [TechType.PinkMushroom] = 5,
+                [TechType.PinkMushroomSpore] = 6
+            };
+
+            Assert.AreEqual(6, testDictionary.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesDiscarded.Count);
+
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroomSpore));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroomSpore));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroomSpore));
+        }
+
+        [Test]
+        public void SetByIndexer_WhenUnique_AllAdded_AltComparer()
+        {
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test", TechTypeExtensions.sTechTypeComparer)
+            {
+                [TechType.AcidMushroom] = 1,
+                [TechType.AcidMushroomSpore] = 2,
+                [TechType.WhiteMushroom] = 3,
+                [TechType.WhiteMushroomSpore] = 4,
+                [TechType.PinkMushroom] = 5,
+                [TechType.PinkMushroomSpore] = 6,
+            };
+
+            Assert.AreEqual(6, testDictionary.Count);
+            Assert.AreEqual(0, testDictionary.DuplicatesDiscarded.Count);
+
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroomSpore));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroomSpore));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroomSpore));
+        }
+
+        [Test]
+        public void SetByIndexer_WhenDupEncountered_OriginalOverwritten_NotVisible()
+        {
+            const int firstValue = 1;
+            const int finalValue = 3;
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test")
+            {
+                [TechType.AcidMushroom] = firstValue,
+                [TechType.WhiteMushroom] = 1,
+                [TechType.AcidMushroom] = 2, // Dup
+                [TechType.PinkMushroom] = 2,
+                [TechType.AcidMushroom] = finalValue  // Dup
+            };
+
+            Assert.AreEqual(1, testDictionary.DuplicatesDiscarded.Count);
+            Assert.AreEqual(2, testDictionary.DuplicatesDiscarded[TechType.AcidMushroom]); // Discarded twice
+
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
+
+            Assert.AreEqual(finalValue, testDictionary[TechType.AcidMushroom]);
+
+            Assert.AreEqual(3, testDictionary.Count);
+        }
+
+        [Test]
+        public void SetByIndexer_WhenDupEncountered_OriginalOverwritten_AltComparer()
+        {
+            const int firstValue = 1;
+            const int finalValue = 3;
+            var testDictionary = new SelfCheckingDictionary<TechType, int>("Test", TechTypeExtensions.sTechTypeComparer)
+            {
+                [TechType.AcidMushroom] = firstValue,
+                [TechType.WhiteMushroom] = 1,
+                [TechType.AcidMushroom] = 2, // Dup
+                [TechType.PinkMushroom] = 2,
+                [TechType.AcidMushroom] = finalValue // Dup
+            };
+
+            Assert.AreEqual(1, testDictionary.DuplicatesDiscarded.Count);
+            Assert.AreEqual(2, testDictionary.DuplicatesDiscarded[TechType.AcidMushroom]); // Discarded twice
+
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.AcidMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.WhiteMushroom));
+            Assert.IsTrue(testDictionary.ContainsKey(TechType.PinkMushroom));
+
+            Assert.AreEqual(finalValue, testDictionary[TechType.AcidMushroom]);
+
+            Assert.AreEqual(3, testDictionary.Count);
         }
     }
 }

--- a/SMLHelper.Tests/packages.config
+++ b/SMLHelper.Tests/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net45" />
+  <package id="NUnit" version="3.11.0" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net45" />
+</packages>

--- a/SMLHelper.sln
+++ b/SMLHelper.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SMLHelper", "SMLHelper\SMLH
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example mod", "Example mod\Example mod.csproj", "{C8FB0981-77D2-47C7-BBEF-A3A9EBACACBF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SMLHelper.Tests", "SMLHelper.Tests\SMLHelper.Tests.csproj", "{EBC4AAF3-A13B-427E-BF99-3AE23EDEB4B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{C8FB0981-77D2-47C7-BBEF-A3A9EBACACBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8FB0981-77D2-47C7-BBEF-A3A9EBACACBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8FB0981-77D2-47C7-BBEF-A3A9EBACACBF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBC4AAF3-A13B-427E-BF99-3AE23EDEB4B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBC4AAF3-A13B-427E-BF99-3AE23EDEB4B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBC4AAF3-A13B-427E-BF99-3AE23EDEB4B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBC4AAF3-A13B-427E-BF99-3AE23EDEB4B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SMLHelper/Handlers/BioReactorHandler.cs
+++ b/SMLHelper/Handlers/BioReactorHandler.cs
@@ -12,7 +12,7 @@
         /// <seealso cref="CraftData.BackgroundType"/>
         public static void SetBioReactorCharge(TechType techType, float charge)
         {
-            BioReactorPatcher.CustomBioreactorCharges[techType] = charge;
+            BioReactorPatcher.CustomBioreactorCharges.Add(techType, charge);
         }
     }
 }

--- a/SMLHelper/Handlers/CraftDataHandler.cs
+++ b/SMLHelper/Handlers/CraftDataHandler.cs
@@ -17,7 +17,7 @@
         /// <seealso cref="TechData"/>
         public static void SetTechData(TechType techType, ITechData techData)
         {
-            CraftDataPatcher.AddToCustomTechData(techType, techData);
+            CraftDataPatcher.CustomTechData.Add(techType, techData);
         }
 
         /// <summary>
@@ -29,7 +29,7 @@
         /// <seealso cref="TechData"/>
         public static void SetTechData(TechType techType, TechData techData)
         {
-            CraftDataPatcher.AddToCustomTechData(techType, techData);
+            CraftDataPatcher.CustomTechData.Add(techType, techData);
         }
 
         /// <summary>

--- a/SMLHelper/Legacy/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Legacy/Patchers/CraftDataPatcher.cs
@@ -40,8 +40,7 @@ namespace SMLHelper.Patchers
 
         internal static void Patch()
         {
-            customTechData.ForEach(x => CraftDataPatcher2.AddToCustomTechData(x.Key, x.Value));
-
+            customTechData.ForEach(x => CraftDataPatcher2.CustomTechData.Add(x.Key, x.Value));
             customHarvestOutputList.ForEach(x => CraftDataPatcher2.CustomHarvestOutputList.Add(x.Key, x.Value));
             customHarvestTypeList.ForEach(x => CraftDataPatcher2.CustomHarvestTypeList.Add(x.Key, x.Value));
             customItemSizes.ForEach(x => CraftDataPatcher2.CustomItemSizes.Add(x.Key, x.Value));

--- a/SMLHelper/Logger.cs
+++ b/SMLHelper/Logger.cs
@@ -50,6 +50,16 @@
                 Log("Error reading EnableDebugLogs.txt configuration file. Defaulted to false", LogLevel.Warn);
             }
         }
+                
+        internal static void Debug(string text) => Log(text, LogLevel.Debug);
+        internal static void Info(string text) => Log(text, LogLevel.Info);
+        internal static void Warn(string text) => Log(text, LogLevel.Warn);
+        internal static void Error(string text) => Log(text, LogLevel.Error);
+
+        internal static void Debug(string text, params object[] args) => Log(text, LogLevel.Debug, args);
+        internal static void Info(string text, params object[] args) => Log(text, LogLevel.Info, args);
+        internal static void Warn(string text, params object[] args) => Log(text, LogLevel.Warn, args);
+        internal static void Error(string text, params object[] args) => Log(text, LogLevel.Error, args);
 
         internal static void Log(string text, LogLevel level = LogLevel.Info)
         {

--- a/SMLHelper/MonoBehaviours/Fixer.cs
+++ b/SMLHelper/MonoBehaviours/Fixer.cs
@@ -29,6 +29,7 @@ namespace SMLHelper.V2.MonoBehaviours
 
             if (transform.position == new Vector3(-5000, -5000, -5000) && gameObject != prefab && Time.time > time)
             {
+                Logger.Debug("Destroying object: " + gameObject);
                 Destroy(gameObject);
             }
         }

--- a/SMLHelper/Patchers/BioReactorPatcher.cs
+++ b/SMLHelper/Patchers/BioReactorPatcher.cs
@@ -2,7 +2,6 @@
 {
     using Harmony;
     using System.Collections.Generic;
-    using Utility;
 
     internal class BioReactorPatcher
     {

--- a/SMLHelper/Patchers/BioReactorPatcher.cs
+++ b/SMLHelper/Patchers/BioReactorPatcher.cs
@@ -8,7 +8,7 @@
     {
         #region Internal Fields
 
-        internal static Dictionary<TechType, float> CustomBioreactorCharges = new Dictionary<TechType, float>(TechTypeExtensions.sTechTypeComparer);
+        internal static IDictionary<TechType, float> CustomBioreactorCharges = new SelfCheckingDictionary<TechType, float>("CustomBioreactorCharges", TechTypeExtensions.sTechTypeComparer);
 
         #endregion
 

--- a/SMLHelper/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Patchers/CraftDataPatcher.cs
@@ -9,18 +9,17 @@
     internal class CraftDataPatcher
     {
         #region Internal Fields
-
-        internal static List<TechType> DuplicateTechDataAttempts = new List<TechType>();
-        internal static Dictionary<TechType, ITechData> CustomTechData = new Dictionary<TechType, ITechData>();
-        internal static Dictionary<TechType, TechType> CustomHarvestOutputList = new Dictionary<TechType, TechType>();
-        internal static Dictionary<TechType, HarvestType> CustomHarvestTypeList = new Dictionary<TechType, HarvestType>();
-        internal static Dictionary<TechType, int> CustomFinalCutBonusList = new Dictionary<TechType, int>(TechTypeExtensions.sTechTypeComparer);
-        internal static Dictionary<TechType, Vector2int> CustomItemSizes = new Dictionary<TechType, Vector2int>();
-        internal static Dictionary<TechType, EquipmentType> CustomEquipmentTypes = new Dictionary<TechType, EquipmentType>();
-        internal static Dictionary<TechType, QuickSlotType> CustomSlotTypes = new Dictionary<TechType, QuickSlotType>();
-        internal static Dictionary<TechType, float> CustomCraftingTimes = new Dictionary<TechType, float>();
-        internal static Dictionary<TechType, TechType> CustomCookedCreatureList = new Dictionary<TechType, TechType>();
-        internal static Dictionary<TechType, CraftData.BackgroundType> CustomBackgroundTypes = new Dictionary<TechType, CraftData.BackgroundType>(TechTypeExtensions.sTechTypeComparer);
+        
+        internal static SelfCheckingDictionary<TechType, ITechData> CustomTechData = new SelfCheckingDictionary<TechType, ITechData>("CustomTechData");
+        internal static SelfCheckingDictionary<TechType, TechType> CustomHarvestOutputList = new SelfCheckingDictionary<TechType, TechType>("CustomHarvestOutputList");
+        internal static SelfCheckingDictionary<TechType, HarvestType> CustomHarvestTypeList = new SelfCheckingDictionary<TechType, HarvestType>("CustomHarvestTypeList");
+        internal static SelfCheckingDictionary<TechType, int> CustomFinalCutBonusList = new SelfCheckingDictionary<TechType, int>("CustomFinalCutBonusList", TechTypeExtensions.sTechTypeComparer);
+        internal static SelfCheckingDictionary<TechType, Vector2int> CustomItemSizes = new SelfCheckingDictionary<TechType, Vector2int>("CustomItemSizes");
+        internal static SelfCheckingDictionary<TechType, EquipmentType> CustomEquipmentTypes = new SelfCheckingDictionary<TechType, EquipmentType>("CustomEquipmentTypes");
+        internal static SelfCheckingDictionary<TechType, QuickSlotType> CustomSlotTypes = new SelfCheckingDictionary<TechType, QuickSlotType>("CustomSlotTypes");
+        internal static SelfCheckingDictionary<TechType, float> CustomCraftingTimes = new SelfCheckingDictionary<TechType, float>("CustomCraftingTimes");
+        internal static SelfCheckingDictionary<TechType, TechType> CustomCookedCreatureList = new SelfCheckingDictionary<TechType, TechType>("CustomCookedCreatureList");
+        internal static SelfCheckingDictionary<TechType, CraftData.BackgroundType> CustomBackgroundTypes = new SelfCheckingDictionary<TechType, CraftData.BackgroundType>("CustomBackgroundTypes", TechTypeExtensions.sTechTypeComparer);
         internal static List<TechType> CustomBuildables = new List<TechType>();
 
         #endregion
@@ -93,15 +92,7 @@
 
         internal static void AddToCustomTechData(TechType techType, ITechData techData)
         {
-            if (CustomTechData.ContainsKey(techType))
-            {
-                Logger.Log($"[ERROR] Custom TechData already exists for '{techType}'. {Environment.NewLine}" +
-                            "All entries will be removed so conflict can be noted and resolved.");
-                DuplicateTechDataAttempts.Add(techType);
-                return; // Error condition exit
-            }
-
-            CustomTechData[techType] = techData;
+            CustomTechData.Add(techType, techData);
         }
 
         #endregion
@@ -145,18 +136,6 @@
 
         private static void AddCustomTechDataToOriginalDictionary()
         {
-            if (DuplicateTechDataAttempts.Count > 0)
-            {
-                Logger.Log($"Removing conflicting TechData entries from patching.{Environment.NewLine}" +
-                           $"This is so the user will take notice and know to resolve the conflict.{Environment.NewLine}" +
-                           "Only one custom TechData may be added per TechType.");
-
-                foreach (TechType dup in DuplicateTechDataAttempts)
-                {
-                    CustomTechData.Remove(dup);
-                }
-            }
-
             Type CraftDataType = typeof(CraftData);
             Type TechDataType = CraftDataType.GetNestedType("TechData", BindingFlags.NonPublic);
             Type IngredientType = CraftDataType.GetNestedType("Ingredient", BindingFlags.NonPublic);

--- a/SMLHelper/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Patchers/CraftDataPatcher.cs
@@ -10,16 +10,16 @@
     {
         #region Internal Fields
         
-        internal static SelfCheckingDictionary<TechType, ITechData> CustomTechData = new SelfCheckingDictionary<TechType, ITechData>("CustomTechData");
-        internal static SelfCheckingDictionary<TechType, TechType> CustomHarvestOutputList = new SelfCheckingDictionary<TechType, TechType>("CustomHarvestOutputList");
-        internal static SelfCheckingDictionary<TechType, HarvestType> CustomHarvestTypeList = new SelfCheckingDictionary<TechType, HarvestType>("CustomHarvestTypeList");
-        internal static SelfCheckingDictionary<TechType, int> CustomFinalCutBonusList = new SelfCheckingDictionary<TechType, int>("CustomFinalCutBonusList", TechTypeExtensions.sTechTypeComparer);
-        internal static SelfCheckingDictionary<TechType, Vector2int> CustomItemSizes = new SelfCheckingDictionary<TechType, Vector2int>("CustomItemSizes");
-        internal static SelfCheckingDictionary<TechType, EquipmentType> CustomEquipmentTypes = new SelfCheckingDictionary<TechType, EquipmentType>("CustomEquipmentTypes");
-        internal static SelfCheckingDictionary<TechType, QuickSlotType> CustomSlotTypes = new SelfCheckingDictionary<TechType, QuickSlotType>("CustomSlotTypes");
-        internal static SelfCheckingDictionary<TechType, float> CustomCraftingTimes = new SelfCheckingDictionary<TechType, float>("CustomCraftingTimes");
-        internal static SelfCheckingDictionary<TechType, TechType> CustomCookedCreatureList = new SelfCheckingDictionary<TechType, TechType>("CustomCookedCreatureList");
-        internal static SelfCheckingDictionary<TechType, CraftData.BackgroundType> CustomBackgroundTypes = new SelfCheckingDictionary<TechType, CraftData.BackgroundType>("CustomBackgroundTypes", TechTypeExtensions.sTechTypeComparer);
+        internal static IDictionary<TechType, ITechData> CustomTechData = new SelfCheckingDictionary<TechType, ITechData>("CustomTechData");
+        internal static IDictionary<TechType, TechType> CustomHarvestOutputList = new SelfCheckingDictionary<TechType, TechType>("CustomHarvestOutputList");
+        internal static IDictionary<TechType, HarvestType> CustomHarvestTypeList = new SelfCheckingDictionary<TechType, HarvestType>("CustomHarvestTypeList");
+        internal static IDictionary<TechType, int> CustomFinalCutBonusList = new SelfCheckingDictionary<TechType, int>("CustomFinalCutBonusList", TechTypeExtensions.sTechTypeComparer);
+        internal static IDictionary<TechType, Vector2int> CustomItemSizes = new SelfCheckingDictionary<TechType, Vector2int>("CustomItemSizes");
+        internal static IDictionary<TechType, EquipmentType> CustomEquipmentTypes = new SelfCheckingDictionary<TechType, EquipmentType>("CustomEquipmentTypes");
+        internal static IDictionary<TechType, QuickSlotType> CustomSlotTypes = new SelfCheckingDictionary<TechType, QuickSlotType>("CustomSlotTypes");
+        internal static IDictionary<TechType, float> CustomCraftingTimes = new SelfCheckingDictionary<TechType, float>("CustomCraftingTimes");
+        internal static IDictionary<TechType, TechType> CustomCookedCreatureList = new SelfCheckingDictionary<TechType, TechType>("CustomCookedCreatureList");
+        internal static IDictionary<TechType, CraftData.BackgroundType> CustomBackgroundTypes = new SelfCheckingDictionary<TechType, CraftData.BackgroundType>("CustomBackgroundTypes", TechTypeExtensions.sTechTypeComparer);
         internal static List<TechType> CustomBuildables = new List<TechType>();
 
         #endregion

--- a/SMLHelper/Patchers/SelfCheckingDictionary.cs
+++ b/SMLHelper/Patchers/SelfCheckingDictionary.cs
@@ -12,7 +12,14 @@
     /// <typeparam name="V"></typeparam>
     internal class SelfCheckingDictionary<K, V> : IDictionary<K, V>
     {
+        /// <summary>
+        /// Maintains a collection of the keys that have encountered duplicates and how many of them were discarded.
+        /// </summary>
         internal readonly Dictionary<K, int> DuplicatesDiscarded;
+
+        /// <summary>
+        /// Maintains the final collection of only unique keys.
+        /// </summary>
         internal readonly Dictionary<K, V> UniqueEntries;
         internal readonly string CollectionName;
 
@@ -30,6 +37,12 @@
             DuplicatesDiscarded = new Dictionary<K, int>(equalityComparer);
         }
 
+        /// <summary>
+        /// Gets a key value pair from the collection or sets a key value pair into the collection.
+        /// When setting, if a key already exists, the previous entry will be discarded.
+        /// </summary>
+        /// <param name="key">The unique key.</param>
+        /// <returns>The value corresponding to the key.</returns>
         public V this[K key]
         {
             get => UniqueEntries[key];
@@ -40,7 +53,7 @@
                     if (DuplicatesDiscarded.ContainsKey(key))
                         DuplicatesDiscarded[key]++;
                     else
-                        DuplicatesDiscarded.Add(key, 1);
+                        DuplicatesDiscarded.Add(key, 1); // Original is overwritten.
 
                     DupFoundLastDiscardedLog(key);
                 }
@@ -54,6 +67,12 @@
         public int Count => UniqueEntries.Count;
         public bool IsReadOnly { get; } = false;
 
+        /// <summary>
+        /// Add a new entry the collection.
+        /// If a duplicate key is found, all entries with that key will be excluded from the final collection.
+        /// </summary>
+        /// <param name="key">The unique key.</param>
+        /// <param name="value">The value.</param>
         public void Add(K key, V value)
         {
             if (DuplicatesDiscarded.ContainsKey(key))
@@ -66,7 +85,7 @@
             if (UniqueEntries.ContainsKey(key))
             {
                 UniqueEntries.Remove(key);
-                DuplicatesDiscarded.Add(key, 1);
+                DuplicatesDiscarded.Add(key, 2); // Original is discarded and new entry is not added.
 
                 DupFoundAllDiscardedLog(key);
                 return;
@@ -75,18 +94,11 @@
             UniqueEntries.Add(key, value);
         }
 
-        private void DupFoundAllDiscardedLog(K key)
-        {
-            Logger.Warn($"{CollectionName} already exists for '{key}'. {Environment.NewLine}" +
-                        "All entries will be removed so conflict can be noted and resolved.");
-        }
-
-        private void DupFoundLastDiscardedLog(K key)
-        {
-            Logger.Warn($"{CollectionName} already exists for '{key}'. {Environment.NewLine}" +
-                        " Original value has been overwritten by later entry.");
-        }
-
+        /// <summary>
+        /// Add a new entry the collection.
+        /// If a duplicate key is found, all entries with that key will be excluded from the final collection.
+        /// </summary>
+        /// <param name="item">The key value pair.</param>
         public void Add(KeyValuePair<K, V> item) => Add(item.Key, item.Value);
 
         public void Clear()
@@ -97,7 +109,7 @@
 
         public bool Contains(KeyValuePair<K, V> item) => UniqueEntries.TryGetValue(item.Key, out V value) && value.Equals(item.Value);
 
-        public bool ContainsKey(K key) => UniqueEntries.ContainsKey(key);
+        public bool ContainsKey(K key) => UniqueEntries.ContainsKey(key) | DuplicatesDiscarded.ContainsKey(key);
 
         public void CopyTo(KeyValuePair<K, V>[] array, int arrayIndex)
         {
@@ -115,6 +127,28 @@
 
         public bool TryGetValue(K key, out V value) => UniqueEntries.TryGetValue(key, out value);
 
-        IEnumerator IEnumerable.GetEnumerator() => UniqueEntries.GetEnumerator();       
+        IEnumerator IEnumerable.GetEnumerator() => UniqueEntries.GetEnumerator();         
+
+        /// <summary>
+        /// Informs the user that all entries for the specified key have been discarded.
+        /// </summary>
+        /// <param name="key">The no longer unique key.</param>
+        private void DupFoundAllDiscardedLog(K key)
+        {
+            Logger.Warn($"{CollectionName} already exists for '{key}'.{Environment.NewLine}" +
+                        $"All entries will be removed so conflict can be noted and resolved.{Environment.NewLine}" +
+                        $"So far we have discarded or overwritten {DuplicatesDiscarded[key]} entries for '{key}'.");
+        }
+
+        /// <summary>
+        /// Informs the user that the previous entry for the specified key has been discarded.
+        /// </summary>
+        /// <param name="key">The no longer unique key.</param>
+        private void DupFoundLastDiscardedLog(K key)
+        {
+            Logger.Warn($"{CollectionName} already exists for '{key}'.{Environment.NewLine}" +
+                        $"Original value has been overwritten by later entry.{Environment.NewLine}" +
+                        $"So far we have discarded or overwritten {DuplicatesDiscarded[key]} entries for '{key}'.");
+        }
     }
 }

--- a/SMLHelper/Patchers/SelfCheckingDictionary.cs
+++ b/SMLHelper/Patchers/SelfCheckingDictionary.cs
@@ -1,0 +1,115 @@
+﻿namespace SMLHelper.V2.Patchers
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    internal class SelfCheckingDictionary<K, V> : IDictionary<K, V>
+    {
+        [NonSerialized] private object _syncRoot;
+
+        internal readonly HashSet<K> DuplicatesFound;
+        internal readonly Dictionary<K, V> UniqueEntries;
+        internal readonly string CollectionName;
+
+        public SelfCheckingDictionary(string collectionName)
+        {
+            CollectionName = collectionName;
+            UniqueEntries = new Dictionary<K, V>();
+            DuplicatesFound = new HashSet<K>();
+        }
+
+        public SelfCheckingDictionary(string collectionName, IEqualityComparer<K> equalityComparer)
+        {
+            CollectionName = collectionName;
+            UniqueEntries = new Dictionary<K, V>(equalityComparer);
+            DuplicatesFound = new HashSet<K>(equalityComparer);
+        }
+
+        public V this[K key]
+        {
+            get => UniqueEntries[key];
+            set => UniqueEntries[key] = value;
+        }
+
+        public ICollection<K> Keys => UniqueEntries.Keys;
+        public ICollection<V> Values => UniqueEntries.Values;
+        public int Count => UniqueEntries.Count;
+        public bool IsReadOnly { get; } = false;
+        public bool IsFixedSize { get; } = false;
+
+        public object SyncRoot
+        {
+            get
+            {
+                if (_syncRoot == null)
+                {
+                    Interlocked.CompareExchange<object>(ref _syncRoot, new object(), null);
+                }
+
+                return _syncRoot;
+            }
+        }
+
+        public bool IsSynchronized { get; } = false;
+
+        public void Add(K key, V value)
+        {
+            if (DuplicatesFound.Contains(key))
+            {
+                DupFoundError(key);
+                return;
+            }
+
+            if (UniqueEntries.ContainsKey(key))
+            {
+                UniqueEntries.Remove(key);
+                DuplicatesFound.Add(key);
+
+                DupFoundError(key);
+                return;
+            }
+
+            UniqueEntries.Add(key, value);
+        }
+
+        private void DupFoundError(K key)
+        {
+            Logger.Log($"[ERROR] {CollectionName} already exists for '{key}'. {Environment.NewLine}" +
+                                        "All entries will be removed so conflict can be noted and resolved.");
+        }
+
+        public void Add(KeyValuePair<K, V> item) => Add(item.Key, item.Value);
+
+        public void Clear()
+        {
+            UniqueEntries.Clear();
+            DuplicatesFound.Clear();
+        }
+
+        public bool Contains(KeyValuePair<K, V> item) => UniqueEntries.TryGetValue(item.Key, out V value) && value.Equals(item.Value);
+
+        public bool ContainsKey(K key) => UniqueEntries.ContainsKey(key);
+
+        public void CopyTo(KeyValuePair<K, V>[] array, int arrayIndex) => throw new NotImplementedException();
+
+        public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => UniqueEntries.GetEnumerator();
+
+        public bool Remove(K key) => UniqueEntries.Remove(key) | DuplicatesFound.Remove(key);
+
+        public bool Remove(KeyValuePair<K, V> item)
+        {
+            if (UniqueEntries.TryGetValue(item.Key, out V value) && value.Equals(item.Value))
+            {
+                return UniqueEntries.Remove(item.Key);
+            }
+
+            return DuplicatesFound.Remove(item.Key);
+        }
+
+        public bool TryGetValue(K key, out V value) => UniqueEntries.TryGetValue(key, out value);
+
+        IEnumerator IEnumerable.GetEnumerator() => UniqueEntries.GetEnumerator();       
+    }
+}

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.1.1.0")]
 [assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: InternalsVisibleTo("SMLHelper.Tests")]

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Patchers\ItemsContainerPatcher.cs" />
     <Compile Include="Patchers\OptionsPanelPatcher.cs" />
     <Compile Include="Patchers\PDAPatcher.cs" />
+    <Compile Include="Patchers\SelfCheckingDictionary.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Legacy\Patchers\TechTypePatcher.cs" />
     <Compile Include="Legacy\Utility.cs" />

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\Dependencies\0Harmony.dll</HintPath>
+      <HintPath>..\Dependencies\0Harmony-1.2.0.1.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\Dependencies\Assembly-CSharp.dll</HintPath>

--- a/SMLHelper/Utility/EnumCacheManager.cs
+++ b/SMLHelper/Utility/EnumCacheManager.cs
@@ -105,9 +105,7 @@
             }
             catch (Exception exception)
             {
-                Logger.Log("Caught exception when reading cache!", LogLevel.Error);
-                Logger.Log("Exception message: " + exception.Message, LogLevel.Error);
-                Logger.Log("StackTrace: " + Environment.NewLine + exception.StackTrace, LogLevel.Error);
+                Logger.Error("Caught exception when reading cache!", Environment.NewLine, exception);
             }
 
             cacheLoaded = true;

--- a/SMLHelper/Utility/PatchUtils.cs
+++ b/SMLHelper/Utility/PatchUtils.cs
@@ -1,7 +1,6 @@
 ﻿namespace SMLHelper.V2
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Reflection;
 
@@ -15,7 +14,7 @@
         internal static void PatchDictionary<K, V>(Type type, string name, IDictionary<K, V> dictionary, BindingFlags flags)
         {
             FieldInfo dictionaryField = type.GetField(name, flags);
-            var dict = dictionaryField.GetValue(null) as IDictionary;
+            var dict = dictionaryField.GetValue(null) as IDictionary<K, V>;
 
             foreach (KeyValuePair<K, V> entry in dictionary)
             {
@@ -23,14 +22,17 @@
             }
         }
 
-        internal static void PatchList(Type type, string name, IList list) => PatchList(type, name, list, BindingFlags.NonPublic | BindingFlags.Static);
+        internal static void PatchList<T>(Type type, string name, IList<T> list)
+        {
+            PatchList(type, name, list, BindingFlags.NonPublic | BindingFlags.Static);
+        }
 
-        internal static void PatchList(Type type, string name, IList list, BindingFlags flags)
+        internal static void PatchList<T>(Type type, string name, IList<T> list, BindingFlags flags)
         {
             FieldInfo listField = type.GetField(name, flags);
-            var craftDataList = listField.GetValue(null) as IList;
+            var craftDataList = listField.GetValue(null) as IList<T>;
 
-            foreach (object obj in list)
+            foreach (T obj in list)
             {
                 craftDataList.Add(obj);
             }

--- a/SMLHelper/Utility/PatchUtils.cs
+++ b/SMLHelper/Utility/PatchUtils.cs
@@ -2,30 +2,28 @@
 {
     using System;
     using System.Collections;
+    using System.Collections.Generic;
     using System.Reflection;
 
     internal class PatchUtils
     {
-        internal static void PatchDictionary(Type type, string name, IDictionary dictionary)
+        internal static void PatchDictionary<K, V>(Type type, string name, IDictionary<K, V> dictionary)
         {
             PatchDictionary(type, name, dictionary, BindingFlags.NonPublic | BindingFlags.Static);
         }
 
-        internal static void PatchDictionary(Type type, string name, IDictionary dictionary, BindingFlags flags)
+        internal static void PatchDictionary<K, V>(Type type, string name, IDictionary<K, V> dictionary, BindingFlags flags)
         {
             FieldInfo dictionaryField = type.GetField(name, flags);
             var dict = dictionaryField.GetValue(null) as IDictionary;
 
-            foreach(DictionaryEntry entry in dictionary)
+            foreach (KeyValuePair<K, V> entry in dictionary)
             {
                 dict[entry.Key] = entry.Value;
             }
         }
 
-        internal static void PatchList(Type type, string name, IList list)
-        {
-            PatchList(type, name, list, BindingFlags.NonPublic | BindingFlags.Static);
-        }
+        internal static void PatchList(Type type, string name, IList list) => PatchList(type, name, list, BindingFlags.NonPublic | BindingFlags.Static);
 
         internal static void PatchList(Type type, string name, IList list, BindingFlags flags)
         {


### PR DESCRIPTION
- New SelfCheckingDictionary automatically checks for and excludes duplicate keys
- Created unit test project with unit tests for the SelfCheckingDictionary
- Removed AddToCustomTechData method from CraftDataHandler and updated usages. No longer needed.
