### PR TITLE
Use publicized assemblies as dependencies to avoid most reflection calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,5 @@ __pycache__/
 *.pyc
 Dependencies/Assembly-CSharp-firstpass.dll
 Dependencies/Assembly-CSharp.dll
+/Dependencies/Assembly-CSharp-firstpass_publicized.dll
+/Dependencies/Assembly-CSharp_publicized.dll

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # SMLHelper
-SMLHelper is a complete library that helps you out on your Subnautica modding adventures by making adding new items, changing items, adding models, sprites a LOT easier. Check out [the wiki page](https://github.com/SMLHelper/SMLHelper/wiki) for details on how to use it.
+SMLHelper is a complete library that helps you out on your Subnautica modding adventures by making adding new items, changing items, adding models, sprites a LOT easier.  
+Check out [the wiki page](https://github.com/SMLHelper/SMLHelper/wiki) for details on how to use it.
 
 ## Contributing
 We would love to have people contribute to SMLHelper.  
 To get started, first fork the repo and then clone it to your local environment.  
 As of version 2.1, SMLHelper has been updated to use Harmony version 1.2.0.1.
 
-As of version 2.2, SMLHelper is now using the _publicized_ versions of `Assembly-CSharp.dll` and `Assembly-CSharp-firstpass.dll` (the originals being located in your `Subnautica_Data/Managed` folder).
+As of version 2.2, SMLHelper is now using the _publicized_ versions of `Assembly-CSharp.dll` and `Assembly-CSharp-firstpass.dll` (the originals being located in your `Subnautica_Data/Managed` folder).  
 To create your own publiciezed DLLs, you will need to download or compile the [Assembly Publicizer](https://github.com/CabbageCrow/AssemblyPublicizer/releases) and follow the [instructions](https://github.com/CabbageCrow/AssemblyPublicizer/blob/master/README.md) to convert the original DLLs into `Assembly-CSharp_publicized.dll` and `Assembly-CSharp-firstpass_publicized.dll`.  
-You will need to copy these DLLs into the `Dependency` folder in order to build the solution.
+You will need to copy these DLLs into the `Dependency` folder of the solution before you can build it.
 
 Then, load up the solution, make your edits, then create your Pull Request!

--- a/README.md
+++ b/README.md
@@ -11,6 +11,3 @@ To create your own publiciezed DLLs, you will need to download or compile the [A
 You will need to copy these DLLs into the `Dependency` folder in order to build the solution.
 
 Then, load up the solution, make your edits, then create your Pull Request!
-
-## Alphabetical list of mods using SMLHelper
-_Moved to https://smlhelper.github.io_

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 SMLHelper is a complete library that helps you out on your Subnautica modding adventures by making adding new items, changing items, adding models, sprites a LOT easier. Check out [the wiki page](https://github.com/SMLHelper/SMLHelper/wiki) for details on how to use it.
 
 ## Contributing
-We would love to have people contribute to SMLHelper. To get started, first fork the repo and then clone it, and then copy Assembly-CSharp.dll and Assembly-CSharp-firstpass.dll (located in your Subnautica_Data/Managed folder) to the Dependencies folder. Then, load up the solution, make your edits and PR them!
+We would love to have people contribute to SMLHelper.  
+To get started, first fork the repo and then clone it to your local environment.  
+As of version 2.1, SMLHelper has been updated to use Harmony version 1.2.0.1.
+
+As of version 2.2, SMLHelper is now using the _publicized_ versions of `Assembly-CSharp.dll` and `Assembly-CSharp-firstpass.dll` (the originals being located in your `Subnautica_Data/Managed` folder).
+To create your own publiciezed DLLs, you will need to download or compile the [Assembly Publicizer](https://github.com/CabbageCrow/AssemblyPublicizer/releases) and follow the [instructions](https://github.com/CabbageCrow/AssemblyPublicizer/blob/master/README.md) to convert the original DLLs into `Assembly-CSharp_publicized.dll` and `Assembly-CSharp-firstpass_publicized.dll`.  
+You will need to copy these DLLs into the `Dependency` folder in order to build the solution.
+
+Then, load up the solution, make your edits, then create your Pull Request!
 
 ## Alphabetical list of mods using SMLHelper
 _Moved to https://smlhelper.github.io_

--- a/SMLHelper/Assets/Spawnable.cs
+++ b/SMLHelper/Assets/Spawnable.cs
@@ -1,7 +1,6 @@
 ﻿namespace SMLHelper.V2.Assets
 {
     using System;
-    using System.Reflection;
     using Handlers;
 
     /// <summary>

--- a/SMLHelper/Legacy/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Legacy/Patchers/CraftDataPatcher.cs
@@ -59,8 +59,6 @@ namespace SMLHelper.Patchers
         public List<IngredientHelper> _ingredients = new List<IngredientHelper>();
         public List<TechType> _linkedItems = new List<TechType>();
 
-        public static Type TechDataType = typeof(CraftData).GetNestedType("TechData", BindingFlags.NonPublic);
-
         public int craftAmount { get { return _craftAmount; } }
 
         public int ingredientCount

--- a/SMLHelper/Patchers/BioReactorPatcher.cs
+++ b/SMLHelper/Patchers/BioReactorPatcher.cs
@@ -15,6 +15,8 @@
 
         internal static void Patch(HarmonyInstance harmony)
         {
+            // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
+            // See README.md for details.
             PatchUtils.PatchDictionary(BaseBioReactor.charge, CustomBioreactorCharges);
 
             Logger.Log("BaseBioReactorPatcher is done.", LogLevel.Debug);

--- a/SMLHelper/Patchers/BioReactorPatcher.cs
+++ b/SMLHelper/Patchers/BioReactorPatcher.cs
@@ -15,7 +15,7 @@
 
         internal static void Patch(HarmonyInstance harmony)
         {
-            PatchUtils.PatchDictionary(typeof(BaseBioReactor), "charge", CustomBioreactorCharges);
+            PatchUtils.PatchDictionary(BaseBioReactor.charge, CustomBioreactorCharges);
 
             Logger.Log("BaseBioReactorPatcher is done.", LogLevel.Debug);
         }

--- a/SMLHelper/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Patchers/CraftDataPatcher.cs
@@ -92,6 +92,8 @@
 
         internal static void Patch(HarmonyInstance harmony)
         {
+            // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
+            // See README.md for details.
             PatchUtils.PatchDictionary(CraftData.harvestOutputList, CustomHarvestOutputList);
             PatchUtils.PatchDictionary(CraftData.harvestTypeList, CustomHarvestTypeList);
             PatchUtils.PatchDictionary(CraftData.harvestFinalCutBonusList, CustomFinalCutBonusList);

--- a/SMLHelper/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Patchers/CraftTreePatcher.cs
@@ -5,7 +5,6 @@
     using System.Reflection;
     using Utility;
     using Crafting;
-    using Assets;
     using System;
 
     internal class CraftTreePatcher

--- a/SMLHelper/Patchers/KnownTechPatcher.cs
+++ b/SMLHelper/Patchers/KnownTechPatcher.cs
@@ -30,6 +30,8 @@
 
             UnlockedAtStart.ForEach(x => KnownTech.Add(x, false));
 
+            // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
+            // See README.md for details.
             List<KnownTech.AnalysisTech> analysisTech = KnownTech.analysisTech;
             IEnumerable<KnownTech.AnalysisTech> techToAdd = AnalysisTech.Where(a => !analysisTech.Any(a2 => a.techType == a2.techType));
 

--- a/SMLHelper/Patchers/KnownTechPatcher.cs
+++ b/SMLHelper/Patchers/KnownTechPatcher.cs
@@ -1,9 +1,9 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
-    using System.Collections.Generic;
-    using System.Reflection;
-    using System.Linq;
     using Harmony;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
 
     internal class KnownTechPatcher
     {
@@ -24,12 +24,13 @@
 
         internal static void InitializePostfix()
         {
-            if (initialized) return;
+            if (initialized)
+                return;
             initialized = true;
 
             UnlockedAtStart.ForEach(x => KnownTech.Add(x, false));
 
-            var analysisTech = (List<KnownTech.AnalysisTech>)typeof(KnownTech).GetField("analysisTech", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+            List<KnownTech.AnalysisTech> analysisTech = KnownTech.analysisTech;
             IEnumerable<KnownTech.AnalysisTech> techToAdd = AnalysisTech.Where(a => !analysisTech.Any(a2 => a.techType == a2.techType));
 
             foreach (KnownTech.AnalysisTech tech in analysisTech)
@@ -37,11 +38,11 @@
                 if (tech.unlockSound != null && tech.techType == TechType.BloodOil)
                     UnlockSound = tech.unlockSound;
 
-                foreach(KnownTech.AnalysisTech customTech in AnalysisTech)
+                foreach (KnownTech.AnalysisTech customTech in AnalysisTech)
                 {
-                    if(tech.techType == customTech.techType)
+                    if (tech.techType == customTech.techType)
                     {
-                        if(customTech.unlockTechTypes != null)
+                        if (customTech.unlockTechTypes != null)
                             tech.unlockTechTypes.AddRange(customTech.unlockTechTypes);
 
                         if (customTech.unlockSound != null)
@@ -56,7 +57,7 @@
                 }
             }
 
-            foreach(KnownTech.AnalysisTech tech in techToAdd)
+            foreach (KnownTech.AnalysisTech tech in techToAdd)
             {
                 if (tech == null) continue;
                 if (tech.unlockSound == null) tech.unlockSound = UnlockSound;

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -1,11 +1,11 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
+    using Harmony;
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Reflection;
     using System.Text;
-    using Harmony;
 
     internal class LanguagePatcher
     {
@@ -23,8 +23,7 @@
 
         internal static void Postfix(ref Language __instance)
         {
-            FieldInfo stringsField = languageType.GetField("strings", BindingFlags.NonPublic | BindingFlags.Instance);
-            var strings = stringsField.GetValue(__instance) as Dictionary<string, string>;
+            Dictionary<string, string> strings = __instance.strings;
             foreach (KeyValuePair<string, string> a in customLines)
             {
                 strings[a.Key] = a.Value;
@@ -188,6 +187,9 @@
             customLines[lineId] = text;
         }
 
-        internal static string TrimTextDelimiters(string value) => value.Trim(TextDelimiterOpen, TextDelimiterClose);
+        internal static string TrimTextDelimiters(string value)
+        {
+            return value.Trim(TextDelimiterOpen, TextDelimiterClose);
+        }
     }
 }

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -23,6 +23,8 @@
 
         internal static void Postfix(ref Language __instance)
         {
+            // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
+            // See README.md for details.
             Dictionary<string, string> strings = __instance.strings;
             foreach (KeyValuePair<string, string> a in customLines)
             {

--- a/SMLHelper/Patchers/PdaPatcher.cs
+++ b/SMLHelper/Patchers/PdaPatcher.cs
@@ -29,6 +29,8 @@
         {
             BlueprintToFragment.Clear();
 
+            // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
+            // See README.md for details.
             Dictionary<TechType, PDAScanner.EntryData> mapping = PDAScanner.mapping;
 
             // Populate BlueprintToFragment for reverse lookup

--- a/SMLHelper/Patchers/PdaPatcher.cs
+++ b/SMLHelper/Patchers/PdaPatcher.cs
@@ -1,9 +1,9 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
+    using Harmony;
     using System;
     using System.Collections.Generic;
     using System.Reflection;
-    using Harmony;
 
     // Special thanks to Gorillazilla9 for sharing this method of fragment count patching
     // https://github.com/Gorillazilla9/SubnauticaFragReqBoost/blob/master/PDAScannerPatcher.cs
@@ -29,9 +29,7 @@
         {
             BlueprintToFragment.Clear();
 
-            var pdaTraverse = Traverse.Create(pdaScannerType);
-            Traverse pdaMappingTraverse = pdaTraverse.Field("mapping");
-            Dictionary<TechType, PDAScanner.EntryData> mapping = pdaMappingTraverse.GetValue<Dictionary<TechType, PDAScanner.EntryData>>();
+            Dictionary<TechType, PDAScanner.EntryData> mapping = PDAScanner.mapping;
 
             // Populate BlueprintToFragment for reverse lookup
             foreach (KeyValuePair<TechType, PDAScanner.EntryData> entry in mapping)

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -1,16 +1,13 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
-    using System.Collections.Generic;
-    using System.Reflection;
     using Assets;
+    using System.Collections.Generic;
 
     internal class SpritePatcher
     {
         internal static void Patch()
         {
-            FieldInfo groupsField = typeof(SpriteManager).GetField("groups", BindingFlags.Static | BindingFlags.NonPublic);
-
-            var groups = (Dictionary<SpriteManager.Group, Dictionary<string, Atlas.Sprite>>)groupsField.GetValue(null);
+            Dictionary<SpriteManager.Group, Dictionary<string, Atlas.Sprite>> groups = SpriteManager.groups;
 
             foreach (SpriteManager.Group moddedGroup in ModSprite.ModSprites.Keys)
             {

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -7,6 +7,8 @@
     {
         internal static void Patch()
         {
+            // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
+            // See README.md for details.
             Dictionary<SpriteManager.Group, Dictionary<string, Atlas.Sprite>> groups = SpriteManager.groups;
 
             foreach (SpriteManager.Group moddedGroup in ModSprite.ModSprites.Keys)

--- a/SMLHelper/Patchers/TechTypePatcher.cs
+++ b/SMLHelper/Patchers/TechTypePatcher.cs
@@ -47,24 +47,14 @@
 
             cacheManager.Add(techType, cache);
 
-            Type techTypeExtensions = typeof(TechTypeExtensions);
-            Traverse traverse = Traverse.Create(techTypeExtensions);
-
-            var stringsNormal = traverse.Field("stringsNormal").GetValue<Dictionary<TechType, string>>();
-            var stringsLowercase = traverse.Field("stringsLowercase").GetValue<Dictionary<TechType, string>>();
-            var techTypesNormal = traverse.Field("techTypesNormal").GetValue<Dictionary<string, TechType>>();
-            var techTypesIgnoreCase = traverse.Field("techTypesIgnoreCase").GetValue<Dictionary<string, TechType>>();
-            var techTypeKeys = traverse.Field("techTypeKeys").GetValue<Dictionary<TechType, string>>();
-            var keyTechTypes = traverse.Field("keyTechTypes").GetValue<Dictionary<string, TechType>>();
-
-            stringsNormal[techType] = name;
-            stringsLowercase[techType] = name.ToLowerInvariant();
-            techTypesNormal[name] = techType;
-            techTypesIgnoreCase[name] = techType;
+            TechTypeExtensions.stringsNormal[techType] = name;
+            TechTypeExtensions.stringsLowercase[techType] = name.ToLowerInvariant();
+            TechTypeExtensions.techTypesNormal[name] = techType;
+            TechTypeExtensions.techTypesIgnoreCase[name] = techType;
 
             string intKey = cache.Index.ToString();
-            techTypeKeys[techType] = intKey;
-            keyTechTypes[intKey] = techType;
+            TechTypeExtensions.techTypeKeys[techType] = intKey;
+            TechTypeExtensions.keyTechTypes[intKey] = techType;
 
             cacheManager.SaveCache();
 
@@ -81,8 +71,7 @@
 
             var bannedIndices = new List<int>();
 
-            FieldInfo keyTechTypesField = typeof(TechTypeExtensions).GetField("keyTechTypes", BindingFlags.NonPublic | BindingFlags.Static);
-            var knownTechTypes = keyTechTypesField.GetValue(null) as Dictionary<string, TechType>;
+            var knownTechTypes = TechTypeExtensions.keyTechTypes;
             foreach (TechType knownTechType in knownTechTypes.Values)
             {
                 int currentTechTypeKey = (int)knownTechType;

--- a/SMLHelper/Patchers/TechTypePatcher.cs
+++ b/SMLHelper/Patchers/TechTypePatcher.cs
@@ -47,6 +47,8 @@
 
             cacheManager.Add(techType, cache);
 
+            // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
+            // See README.md for details.
             TechTypeExtensions.stringsNormal[techType] = name;
             TechTypeExtensions.stringsLowercase[techType] = name.ToLowerInvariant();
             TechTypeExtensions.techTypesNormal[name] = techType;

--- a/SMLHelper/Properties/AssemblyInfo.cs
+++ b/SMLHelper/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.2.1.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]
 [assembly: InternalsVisibleTo("SMLHelper.Tests")]

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -26,6 +26,7 @@
     <DocumentationFile>bin\Debug\SMLHelper.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <LangVersion>7.3</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
@@ -36,16 +37,19 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>7.3</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>..\Dependencies\0Harmony-1.2.0.1.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\Dependencies\Assembly-CSharp.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass_publicized, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Dependencies\Assembly-CSharp-firstpass_publicized.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\Dependencies\Assembly-CSharp-firstpass.dll</HintPath>
+    <Reference Include="Assembly-CSharp_publicized, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Dependencies\Assembly-CSharp_publicized.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SMLHelper/Utility/PatchUtils.cs
+++ b/SMLHelper/Utility/PatchUtils.cs
@@ -1,40 +1,22 @@
 ﻿namespace SMLHelper.V2
 {
-    using System;
     using System.Collections.Generic;
-    using System.Reflection;
 
     internal class PatchUtils
     {
-        internal static void PatchDictionary<K, V>(Type type, string name, IDictionary<K, V> dictionary)
+        internal static void PatchDictionary<KeyType, ValueType>(Dictionary<KeyType, ValueType> original, IDictionary<KeyType, ValueType> patches)
         {
-            PatchDictionary(type, name, dictionary, BindingFlags.NonPublic | BindingFlags.Static);
-        }
-
-        internal static void PatchDictionary<K, V>(Type type, string name, IDictionary<K, V> dictionary, BindingFlags flags)
-        {
-            FieldInfo dictionaryField = type.GetField(name, flags);
-            var dict = dictionaryField.GetValue(null) as IDictionary<K, V>;
-
-            foreach (KeyValuePair<K, V> entry in dictionary)
+            foreach (KeyValuePair<KeyType, ValueType> entry in patches)
             {
-                dict[entry.Key] = entry.Value;
+                original[entry.Key] = entry.Value;
             }
         }
 
-        internal static void PatchList<T>(Type type, string name, IList<T> list)
+        internal static void PatchList<ValueType>(List<ValueType> original, IList<ValueType> patches)
         {
-            PatchList(type, name, list, BindingFlags.NonPublic | BindingFlags.Static);
-        }
-
-        internal static void PatchList<T>(Type type, string name, IList<T> list, BindingFlags flags)
-        {
-            FieldInfo listField = type.GetField(name, flags);
-            var craftDataList = listField.GetValue(null) as IList<T>;
-
-            foreach (T obj in list)
+            foreach (ValueType entry in patches)
             {
-                craftDataList.Add(obj);
+                original.Add(entry);
             }
         }
     }

--- a/SMLHelper/mod.json
+++ b/SMLHelper/mod.json
@@ -2,7 +2,7 @@
   "Id": "SMLHelper",
   "DisplayName": "Modding Helper (SMLHelper)",
   "Author": "AHK1221 & PrimeSonic & AlexejheroYTB",
-  "Version": "2.2.0",
+  "Version": "2.2.1",
   "Enable": true,
   "Game": "Subnautica",
   "Priority": "Last",


### PR DESCRIPTION
 - Now using the publicized versions of Assembly-CSharp and firstpass
- Greatly reduced the amount of necessary Reflection as many private fields and types can now be accessed directly

Made possible thanks to https://github.com/CabbageCrow/AssemblyPublicizer