### PR TITLE
Language Override BugFix

### DIFF
--- a/SMLHelper.Tests/LanguagePatcherTests.cs
+++ b/SMLHelper.Tests/LanguagePatcherTests.cs
@@ -8,6 +8,12 @@
     [TestFixture]
     public class LanguagePatcherTests
     {
+        private static readonly IEnumerable<string> Keys = new string[]
+        {
+            "Key",
+            "Tooltip_Key",            
+        };
+
         private static readonly IEnumerable<string> CustomValues = new string[]
         {
             // No special tokens
@@ -65,23 +71,24 @@
         public void ExtractCustomLinesFromText_WhenTextIsValid_MultipleEntries_KeyIsKnown_Overrides(
             [ValueSource(nameof(LineEndings))] string endOfLine,
             [ValueSource(nameof(CustomValues))] string customValue1,
-            [ValueSource(nameof(CustomValues))] string customValue2)
+            [ValueSource(nameof(CustomValues))] string customValue2,
+            [ValueSource(nameof(Keys))] string secondKey)
         {
             var originalLines = new Dictionary<string, string>
             {
                 { "Key1", "OriginalValue1" },
-                { "Key2", "OriginalValue2" },
+                { secondKey, "OriginalValue2" },
             };
 
             string text = "Key1:{" + customValue1 + "}" + endOfLine +
-                          "Key2:{" + customValue2 + "}" + endOfLine;
+                          secondKey + ":{" + customValue2 + "}" + endOfLine;
             Console.WriteLine("TestText");
             Console.WriteLine(text);
             int overridesApplied = LanguagePatcher.ExtractCustomLinesFromText("Test1", text, originalLines);
 
             Assert.AreEqual(2, overridesApplied);
             Assert.AreEqual(customValue1, LanguagePatcher.GetCustomLine("Key1"));
-            Assert.AreEqual(customValue2, LanguagePatcher.GetCustomLine("Key2"));
+            Assert.AreEqual(customValue2, LanguagePatcher.GetCustomLine(secondKey));
         }
     }
 }

--- a/SMLHelper.Tests/LanguagePatcherTests.cs
+++ b/SMLHelper.Tests/LanguagePatcherTests.cs
@@ -13,6 +13,7 @@
             "CustomValue1", "CustomValue1{0}", "{0}CustomValue1", "{0}CustomValue1{1}",
             "{0}Custom{1}Value1{2}", "Custom{0}Value1", "Custom\nValue1", "\nCustomValue1",
             "CustomValue1\n", "\nCustom\nValue1\n", "Custom{0}\n{1}Value1",
+            "Custom-Value1\n", "\nCustom_Value1\n", "Custom{0}:{1}Value1",
         };
 
         private static readonly IEnumerable<string> CustomValues2 = new string[]
@@ -20,6 +21,7 @@
             "2CustomValue", "2CustomValue{0}", "{0}2CustomValue", "{0}2CustomValue{1}",
             "{0}2Custom{1}Value{2}", "2Custom{0}Value", "2Custom\nValue", "\n2CustomValue",
             "2CustomValue\n", "2\nCustom\nValue\n", "2Custom{0}\n{1}Value",
+            "2Custom-Value\n", "2\nCustom_Value\n", "2Custom{0}:{1}Value",
         };
 
         [TestCaseSource(nameof(CustomValues1))]

--- a/SMLHelper.Tests/LanguagePatcherTests.cs
+++ b/SMLHelper.Tests/LanguagePatcherTests.cs
@@ -1,0 +1,34 @@
+﻿namespace SMLHelper.Tests
+{
+    using NUnit.Framework;
+    using SMLHelper.V2.Patchers;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    [TestFixture]
+    public class LanguagePatcherTests
+    {
+        [TestCase("CustomValue")]
+        [TestCase("CustomValue{0}")]
+        [TestCase("{0}CustomValue")]
+        [TestCase("{0}CustomValue{1}")]
+        [TestCase("Custom{0}Value")]
+        [TestCase("Custom\nValue")]
+        [TestCase("Custom{0}\n{1}Value")] // <-- Currently failing
+        public void ExtractCustomLinesFromText_WhenTextIsValid_SingleEntry_KeyIsKnown_Overrides(string customValue)
+        {
+            var originalLines = new Dictionary<string, string>
+            {
+                { "Key", "OriginalValue" }
+            };
+
+            string text = "Key:{" + customValue + "}";
+
+            int overridesApplied = LanguagePatcher.ExtractCustomLinesFromText("Test1", text, originalLines);
+
+            Assert.AreEqual(1, overridesApplied);
+            Assert.AreEqual(customValue, LanguagePatcher.GetCustomLine("Key"));
+        }
+    }
+}

--- a/SMLHelper.Tests/LanguagePatcherTests.cs
+++ b/SMLHelper.Tests/LanguagePatcherTests.cs
@@ -4,18 +4,25 @@
     using SMLHelper.V2.Patchers;
     using System;
     using System.Collections.Generic;
-    using System.Text;
 
     [TestFixture]
     public class LanguagePatcherTests
     {
-        [TestCase("CustomValue")]
-        [TestCase("CustomValue{0}")]
-        [TestCase("{0}CustomValue")]
-        [TestCase("{0}CustomValue{1}")]
-        [TestCase("Custom{0}Value")]
-        [TestCase("Custom\nValue")]
-        [TestCase("Custom{0}\n{1}Value")] // <-- Currently failing
+        private static readonly IEnumerable<string> CustomValues1 = new string[]
+        {
+            "CustomValue1", "CustomValue1{0}", "{0}CustomValue1", "{0}CustomValue1{1}",
+            "{0}Custom{1}Value1{2}", "Custom{0}Value1", "Custom\nValue1", "\nCustomValue1",
+            "CustomValue1\n", "\nCustom\nValue1\n", "Custom{0}\n{1}Value1",
+        };
+
+        private static readonly IEnumerable<string> CustomValues2 = new string[]
+        {
+            "2CustomValue", "2CustomValue{0}", "{0}2CustomValue", "{0}2CustomValue{1}",
+            "{0}2Custom{1}Value{2}", "2Custom{0}Value", "2Custom\nValue", "\n2CustomValue",
+            "2CustomValue\n", "2\nCustom\nValue\n", "2Custom{0}\n{1}Value",
+        };
+
+        [TestCaseSource(nameof(CustomValues1))]
         public void ExtractCustomLinesFromText_WhenTextIsValid_SingleEntry_KeyIsKnown_Overrides(string customValue)
         {
             var originalLines = new Dictionary<string, string>
@@ -25,10 +32,36 @@
 
             string text = "Key:{" + customValue + "}";
 
+            Console.WriteLine("TestText");
+            Console.WriteLine(text);
             int overridesApplied = LanguagePatcher.ExtractCustomLinesFromText("Test1", text, originalLines);
 
             Assert.AreEqual(1, overridesApplied);
             Assert.AreEqual(customValue, LanguagePatcher.GetCustomLine("Key"));
+        }
+
+
+        [Test, Combinatorial]
+        public void ExtractCustomLinesFromText_WhenTextIsValid_MultipleEntries_KeyIsKnown_Overrides(
+            [Values("\n", "\r\n")] string endOfLine,
+            [ValueSource(nameof(CustomValues1))] string customValue1,
+            [ValueSource(nameof(CustomValues2))] string customValue2)
+        {
+            var originalLines = new Dictionary<string, string>
+            {
+                { "Key1", "OriginalValue1" },
+                { "Key2", "OriginalValue2" },
+            };
+
+            string text = "Key1:{" + customValue1 + "}" + endOfLine +
+                          "Key2:{" + customValue2 + "}" + endOfLine;
+            Console.WriteLine("TestText");
+            Console.WriteLine(text);
+            int overridesApplied = LanguagePatcher.ExtractCustomLinesFromText("Test1", text, originalLines);
+
+            Assert.AreEqual(2, overridesApplied);
+            Assert.AreEqual(customValue1, LanguagePatcher.GetCustomLine("Key1"));
+            Assert.AreEqual(customValue2, LanguagePatcher.GetCustomLine("Key2"));
         }
     }
 }

--- a/SMLHelper.Tests/LanguagePatcherTests.cs
+++ b/SMLHelper.Tests/LanguagePatcherTests.cs
@@ -8,31 +8,49 @@
     [TestFixture]
     public class LanguagePatcherTests
     {
-        private static readonly IEnumerable<string> CustomValues1 = new string[]
+        private static readonly IEnumerable<string> CustomValues = new string[]
         {
-            "CustomValue1", "CustomValue1{0}", "{0}CustomValue1", "{0}CustomValue1{1}",
-            "{0}Custom{1}Value1{2}", "Custom{0}Value1", "Custom\nValue1", "\nCustomValue1",
-            "CustomValue1\n", "\nCustom\nValue1\n", "Custom{0}\n{1}Value1",
-            "Custom-Value1\n", "\nCustom_Value1\n", "Custom{0}:{1}Value1",
+            // No special tokens
+            "CustomValue",
+            "CustomValue1",
+            "2Custom:Value1",
+            "CustomValue%",
+            // string.format tokens
+            "CustomValue{0}",
+            "{0}CustomValue",
+            "{0}CustomValue{1}",
+            "{0}Custom{1}Value{2}",
+            "Custom{0}Value",
+            // With Unity line breaks
+            "Custom\nValue",
+            "\nCustomValue",
+            "CustomValue\n",
+            "\nCustom\nValue\n",
+            // With mix
+            "Custom:{0}\n{1}:Value;",
+            "Custom-Value\n{0}",
+            "#1\nCustom_Value\n",
+            "Custom{0}:{1}%Value%",
         };
 
-        private static readonly IEnumerable<string> CustomValues2 = new string[]
+        private static readonly IEnumerable<string> LineEndings = new string[]
         {
-            "2CustomValue", "2CustomValue{0}", "{0}2CustomValue", "{0}2CustomValue{1}",
-            "{0}2Custom{1}Value{2}", "2Custom{0}Value", "2Custom\nValue", "\n2CustomValue",
-            "2CustomValue\n", "2\nCustom\nValue\n", "2Custom{0}\n{1}Value",
-            "2Custom-Value\n", "2\nCustom_Value\n", "2Custom{0}:{1}Value",
+            new string(new char[]{'\n' }),
+            new string(new char[]{'\r', '\n' }),
+            string.Empty,
         };
 
-        [TestCaseSource(nameof(CustomValues1))]
-        public void ExtractCustomLinesFromText_WhenTextIsValid_SingleEntry_KeyIsKnown_Overrides(string customValue)
+        [Test, Combinatorial]
+        public void ExtractCustomLinesFromText_WhenTextIsValid_SingleEntry_KeyIsKnown_Overrides(
+            [ValueSource(nameof(LineEndings))] string endOfLine,
+            [ValueSource(nameof(CustomValues))] string customValue)
         {
             var originalLines = new Dictionary<string, string>
             {
                 { "Key", "OriginalValue" }
             };
 
-            string text = "Key:{" + customValue + "}";
+            string text = "Key:{" + customValue + "}" + endOfLine;
 
             Console.WriteLine("TestText");
             Console.WriteLine(text);
@@ -45,9 +63,9 @@
 
         [Test, Combinatorial]
         public void ExtractCustomLinesFromText_WhenTextIsValid_MultipleEntries_KeyIsKnown_Overrides(
-            [Values("\n", "\r\n")] string endOfLine,
-            [ValueSource(nameof(CustomValues1))] string customValue1,
-            [ValueSource(nameof(CustomValues2))] string customValue2)
+            [ValueSource(nameof(LineEndings))] string endOfLine,
+            [ValueSource(nameof(CustomValues))] string customValue1,
+            [ValueSource(nameof(CustomValues))] string customValue2)
         {
             var originalLines = new Dictionary<string, string>
             {

--- a/SMLHelper.Tests/SMLHelper.Tests.csproj
+++ b/SMLHelper.Tests/SMLHelper.Tests.csproj
@@ -54,6 +54,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LanguagePatcherTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SelfCheckingDictionaryTests.cs" />
   </ItemGroup>

--- a/SMLHelper.Tests/SMLHelper.Tests.csproj
+++ b/SMLHelper.Tests/SMLHelper.Tests.csproj
@@ -42,7 +42,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\Dependencies\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\Dependencies\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>

--- a/SMLHelper.Tests/SelfCheckingDictionaryTests.cs
+++ b/SMLHelper.Tests/SelfCheckingDictionaryTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace SMLHelper.Tests
 {
     using NUnit.Framework;
+    using SMLHelper.V2;
     using SMLHelper.V2.Patchers;
 
     [TestFixture]
@@ -103,6 +104,7 @@
         [Test]
         public void Add_StepByStep_DupsRemoved()
         {
+            Logger.Initialized = true;
             var testDictionary = new SelfCheckingDictionary<TechType, int>("Test");
 
             Assert.AreEqual(0, testDictionary.Count);

--- a/SMLHelper/Handlers/TechTypeHandler.cs
+++ b/SMLHelper/Handlers/TechTypeHandler.cs
@@ -30,12 +30,13 @@
             // Register the TechType.
             TechType techType = TechTypePatcher.AddTechType(internalName);
 
+            string tooltipKey = "Tooltip_" + internalName;
             // Register Language lines.
-            LanguagePatcher.AddCustomLanguageLine(modName, internalName, displayName);
-            LanguagePatcher.AddCustomLanguageLine(modName, "Tooltip_" + internalName, tooltip);
+            LanguagePatcher.AddCustomLanguageLine(modName, internalName, displayName);            
+            LanguagePatcher.AddCustomLanguageLine(modName, tooltipKey, tooltip);
 
             Dictionary<TechType, string> valueToString = TooltipFactory.techTypeTooltipStrings.valueToString;
-            valueToString[techType] = "Tooltip_" + internalName;
+            valueToString[techType] = tooltipKey;
 
             // Unlock the TechType on start
             if (unlockAtStart)

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -191,7 +191,7 @@
 
         internal static string TrimTextDelimiters(string value)
         {
-            return value.Trim(TextDelimiterOpen, TextDelimiterClose);
+            return value.Substring(1, value.Length - 2);
         }
     }
 }

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -16,7 +16,7 @@
         private const char TextDelimiterOpen = '{';
         private const char TextDelimiterClose = '}';
         private const char KeyValueSeparator = ':';
-        private static readonly Regex OverrideRegex = new Regex("(?<key>[\\w]+)\\s*:\\s*{(?<value>([~!@#$%^&*()\\-_=+\\[\\];:\"',<>\\/?]|{\\d+}|[\\w\\s\n])+)}(\n|\r\n)*", RegexOptions.Compiled | RegexOptions.Multiline);
+        private static readonly Regex OverrideRegex = new Regex("(?<key>[\\w]+)\\s*:\\s*{(?<value>([~!@#$%^&*()\\-_=+\\[\\];:\"',<>\\/?]|{\\d+}|[\\w\\s\n])+)}(\n|\r\n)*", RegexOptions.Multiline);
 
         private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> customLines = new Dictionary<string, string>();
@@ -57,8 +57,6 @@
 
         private static void WriteOriginalCustomLines()
         {
-            Logger.Log("Writing original language files.", LogLevel.Debug);
-
             if (!Directory.Exists(LanguageOrigDir))
                 Directory.CreateDirectory(LanguageOrigDir);
 

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -20,8 +20,12 @@
 
         private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> customLines = new Dictionary<string, string>();
-
         private static Type languageType = typeof(Language);
+
+        internal static string GetCustomLine(string key)
+        {
+            return customLines[key];
+        }
 
         internal static void Postfix(ref Language __instance)
         {
@@ -108,27 +112,34 @@
 
                 Dictionary<string, string> originalLines = originalCustomLines[modName];
 
-                MatchCollection matches = Regex.Matches(text, OverrideRegex, RegexOptions.Multiline);
-
-                int overridesApplied = 0;
-                foreach (Match match in matches)
-                {
-                    string key = match.Groups["key"].Value;
-                    string value = match.Groups["value"].Value;
-
-                    if (!originalLines.ContainsKey(key))
-                    {
-                        Logger.Log($"Key '{key}' in language override file for '{modName}' did not match an original key.", LogLevel.Warn);
-                        continue; // Skip keys we don't recognize
-                    }
-
-                    customLines[key] = value;
-
-                    overridesApplied++;
-                }
+                int overridesApplied = ExtractCustomLinesFromText(modName, text, originalLines);
 
                 Logger.Log($"Applied {overridesApplied} language overrides to mod {modName}.", LogLevel.Info);
             }
+        }
+
+        internal static int ExtractCustomLinesFromText(string modName, string text, Dictionary<string, string> originalLines)
+        {
+            MatchCollection matches = Regex.Matches(text, OverrideRegex, RegexOptions.Multiline);
+
+            int overridesApplied = 0;
+            foreach (Match match in matches)
+            {
+                string key = match.Groups["key"].Value;
+                string value = match.Groups["value"].Value;
+
+                if (!originalLines.ContainsKey(key))
+                {
+                    Logger.Log($"Key '{key}' in language override file for '{modName}' did not match an original key.", LogLevel.Warn);
+                    continue; // Skip keys we don't recognize
+                }
+
+                customLines[key] = value;
+
+                overridesApplied++;
+            }
+
+            return overridesApplied;
         }
 
         internal static void AddCustomLanguageLine(string modAssemblyName, string lineId, string text)

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -99,7 +99,7 @@
 
             foreach (string file in files)
             {
-                string modName = Path.GetFileName(file).Replace(".txt", string.Empty);
+                string modName = Path.GetFileNameWithoutExtension(file);
 
                 if (!originalCustomLines.ContainsKey(modName))
                     continue; // Not for a mod we know about

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -16,7 +16,7 @@
         private const char TextDelimiterOpen = '{';
         private const char TextDelimiterClose = '}';
         private const char KeyValueSeparator = ':';
-        private const string OverrideRegex = @"^(?<key>\w+?)\s*?:\s*?{(?<value>[\s\S]+?)}(?=\Z|(\n|\n\r|\r\n)(\w+?:))";
+        private static readonly Regex OverrideRegex = new Regex("(?<key>[\\w]+)\\s*:\\s*{(?<value>([~!@#$%^&*()\\-_=+\\[\\];:\"',<>\\/?]|{\\d+}|[\\w\\s\n])+)}(\n|\r\n)*", RegexOptions.Compiled | RegexOptions.Multiline);
 
         private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> customLines = new Dictionary<string, string>();
@@ -120,7 +120,7 @@
 
         internal static int ExtractCustomLinesFromText(string modName, string text, Dictionary<string, string> originalLines)
         {
-            MatchCollection matches = Regex.Matches(text, OverrideRegex, RegexOptions.Multiline);
+            MatchCollection matches = OverrideRegex.Matches(text);
 
             int overridesApplied = 0;
             foreach (Match match in matches)

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -64,15 +64,12 @@
             int filesWritten = 0;
             foreach (string modKey in originalCustomLines.Keys)
             {
-                if (!FileNeedsRewrite(modKey))
-                    continue; // File is identical to captured lines. No need to rewrite it.
-
                 WriteOriginalLinesFile(modKey);
                 filesWritten++;
             }
 
             if (filesWritten > 0)
-                Logger.Log($"Updated {filesWritten} of {originalCustomLines.Count} original language files.", LogLevel.Info);
+                Logger.Log($"Updated {filesWritten} original language files.", LogLevel.Debug);
         }
 
         private static void WriteOriginalLinesFile(string modKey)
@@ -132,43 +129,6 @@
 
                 Logger.Log($"Applied {overridesApplied} language overrides to mod {modName}.", LogLevel.Info);
             }
-        }
-
-        private static bool FileNeedsRewrite(string modKey)
-        {
-            Dictionary<string, string> modCustomLines = originalCustomLines[modKey];
-            string fileName = $"{LanguageOrigDir}/{modKey}.txt";
-
-            if (!File.Exists(fileName))
-                return true; // File not found
-
-            string[] lines = File.ReadAllLines(fileName, Encoding.UTF8);
-
-            if (lines.Length != modCustomLines.Count)
-                return true; // Difference in line count
-
-            // Confirm if the file actually needs to be updated
-            foreach (string line in lines)
-            {
-                string[] split = line.Split(new[] { KeyValueSeparator }, 2, StringSplitOptions.RemoveEmptyEntries);
-
-                string lineKey = split[0];
-                string lineValue = TrimTextDelimiters(split[1]);
-
-                if (modCustomLines.TryGetValue(lineKey, out string origValue))
-                {
-                    if (origValue != lineValue)
-                    {
-                        return true; // Difference in line content
-                    }
-                }
-                else
-                {
-                    return true; // Key not found
-                }
-            }
-
-            return false; // All lines matched and valid
         }
 
         internal static void AddCustomLanguageLine(string modAssemblyName, string lineId, string text)

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -111,7 +111,7 @@
 
                 Dictionary<string, string> originalLines = originalCustomLines[modName];
 
-                MatchCollection matches = Regex.Matches(text, OverrideRegex);
+                MatchCollection matches = Regex.Matches(text, OverrideRegex, RegexOptions.Multiline);
 
                 int overridesApplied = 0;
                 foreach (Match match in matches)

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -150,10 +150,7 @@
             // Confirm if the file actually needs to be updated
             foreach (string line in lines)
             {
-                string[] split = line.Split(new[] { KeyValueSeparator }, StringSplitOptions.RemoveEmptyEntries);
-
-                if (split.Length != 2)
-                    return true; // Malformatted, likely externally edited
+                string[] split = line.Split(new[] { KeyValueSeparator }, 2, StringSplitOptions.RemoveEmptyEntries);
 
                 string lineKey = split[0];
                 string lineValue = TrimTextDelimiters(split[1]);

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -16,7 +16,7 @@
         private const char TextDelimiterOpen = '{';
         private const char TextDelimiterClose = '}';
         private const char KeyValueSeparator = ':';
-        private const string OverrideRegex = @"^(?<key>\w+?)\s*?:\s*?{(?<value>[\s\S]+?)}(?=\Z|(\n\r*?)(\w+?:))";
+        private const string OverrideRegex = @"^(?<key>\w+?)\s*?:\s*?{(?<value>[\s\S]+?)}(?=\Z|(\n|\n\r|\r\n)(\w+?:))";
 
         private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> customLines = new Dictionary<string, string>();

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -16,7 +16,7 @@
         private const char TextDelimiterOpen = '{';
         private const char TextDelimiterClose = '}';
         private const char KeyValueSeparator = ':';
-        private const string OverrideRegex = @"^(?<key>\w+?)\s*?:\s*?{(?<value>[\s\S]+?)}$";
+        private const string OverrideRegex = @"^(?<key>\w+?)\s*?:\s*?{(?<value>[\s\S]+?)}(?=\Z|(\n\r*?)(\w+?:))";
 
         private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> customLines = new Dictionary<string, string>();

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -16,7 +16,7 @@
         private const char TextDelimiterOpen = '{';
         private const char TextDelimiterClose = '}';
         private const char KeyValueSeparator = ':';
-        private const string OverrideRegex = "^(?<key>\\w+?)\\s*?:\\s*?{(?<value>[\\s\\S]+?)}$";
+        private const string OverrideRegex = @"^(?<key>\w+?)\s*?:\s*?{(?<value>[\s\S]+?)}$";
 
         private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> customLines = new Dictionary<string, string>();
@@ -138,11 +138,6 @@
 
             originalCustomLines[modAssemblyName][lineId] = text;
             customLines[lineId] = text;
-        }
-
-        internal static string TrimTextDelimiters(string value)
-        {
-            return value.Substring(1, value.Length - 2);
         }
     }
 }

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -16,7 +16,7 @@
         private const char TextDelimiterOpen = '{';
         private const char TextDelimiterClose = '}';
         private const char KeyValueSeparator = ':';
-        private static readonly Regex OverrideRegex = new Regex("(?<key>[\\w]+)\\s*:\\s*{(?<value>([~!@#$%^&*()\\-_=+\\[\\];:\"',<>\\/?]|{\\d+}|[\\w\\s\n])+)}(\n|\r\n)*", RegexOptions.Multiline);
+        private static readonly Regex OverrideRegex = new Regex("(?<key>[\\w_]+)\\s*:\\s*{(?<value>([~!@#$%^&*()\\-_=+\\[\\];:\"',<>\\/?]|{\\d+}|[\\w\\s\n])+)}(\n|\r\n)*", RegexOptions.Multiline);
 
         private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> customLines = new Dictionary<string, string>();

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -16,7 +16,7 @@
         private const char TextDelimiterOpen = '{';
         private const char TextDelimiterClose = '}';
         private const char KeyValueSeparator = ':';
-        private const string OverrideRegex = "(?<key>\\w+?)\\s*?:\\s*?{(?<value>[\\s\\S]+?)}$";
+        private const string OverrideRegex = "^(?<key>\\w+?)\\s*?:\\s*?{(?<value>[\\s\\S]+?)}$";
 
         private static readonly Dictionary<string, Dictionary<string, string>> originalCustomLines = new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> customLines = new Dictionary<string, string>();

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -18,7 +18,7 @@
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
Closes #90 **Language Overrides not compatible with string.format**

Right now this only fixes issues caused by a `string.format` placeholders `{#}` being at the start or end of a language string.  
This was easily resolved by using an index/length based trimming instead of a character based trimming.

However, there are still other issues to resolve:
1. Language lines that include a line break `\n` are not properly handled by the LanguageOverride feature, as it depend on explicit line breaks to function.
2. Language lines that include the special character chosen to be the key-value separator (currently `:`) also fail parsing.

It's likely that we need to use a completely different serialization structure, likely using one that won't have issues with common special characters and `string.format` placeholders.

---

Closes #97 