### PR TITLE
KnownTech AnalysisTech entry DeDuplication

### DIFF
--- a/SMLHelper/Handlers/KnownTechHandler.cs
+++ b/SMLHelper/Handlers/KnownTechHandler.cs
@@ -1,9 +1,9 @@
 ﻿namespace SMLHelper.V2.Handlers
 {
+    using Interfaces;
+    using Patchers;
     using System.Collections.Generic;
     using System.Linq;
-    using Patchers;
-    using Interfaces;
     using UnityEngine;
 
     /// <summary>
@@ -40,14 +40,24 @@
 
         internal void AddAnalysisTech(TechType techTypeToBeAnalysed, IEnumerable<TechType> techTypesToUnlock, string UnlockMessage = "NotificationBlueprintUnlocked", FMODAsset UnlockSound = null, UnityEngine.Sprite UnlockSprite = null)
         {
-            KnownTechPatcher.AnalysisTech.Add(new KnownTech.AnalysisTech()
+            if (KnownTechPatcher.AnalysisTech.TryGetValue(techTypeToBeAnalysed, out KnownTech.AnalysisTech existingEntry))
             {
-                techType = techTypeToBeAnalysed,
-                unlockMessage = UnlockMessage,
-                unlockSound = UnlockSound,
-                unlockPopup = UnlockSprite,
-                unlockTechTypes = techTypesToUnlock.ToList()
-            });
+                existingEntry.unlockMessage = existingEntry.unlockMessage ?? UnlockMessage;
+                existingEntry.unlockSound = existingEntry.unlockSound ?? UnlockSound;
+                existingEntry.unlockPopup = existingEntry.unlockPopup ?? UnlockSprite;
+                existingEntry.unlockTechTypes.AddRange(techTypesToUnlock);
+            }
+            else
+            {
+                KnownTechPatcher.AnalysisTech.Add(techTypeToBeAnalysed, new KnownTech.AnalysisTech()
+                {
+                    techType = techTypeToBeAnalysed,
+                    unlockMessage = UnlockMessage,
+                    unlockSound = UnlockSound,
+                    unlockPopup = UnlockSprite,
+                    unlockTechTypes = techTypesToUnlock.ToList()
+                });
+            }
         }
 
         /// <summary>
@@ -62,14 +72,7 @@
         /// <param name="UnlockSprite">The sprite that shows up when you unlock the blueprint.</param>
         public static void SetAnalysisTechEntry(TechType techTypeToBeAnalysed, IEnumerable<TechType> techTypesToUnlock, string UnlockMessage = "NotificationBlueprintUnlocked", FMODAsset UnlockSound = null, UnityEngine.Sprite UnlockSprite = null)
         {
-            KnownTechPatcher.AnalysisTech.Add(new KnownTech.AnalysisTech()
-            {
-                techType = techTypeToBeAnalysed,
-                unlockMessage = UnlockMessage,
-                unlockSound = UnlockSound,
-                unlockPopup = UnlockSprite,
-                unlockTechTypes = techTypesToUnlock.ToList()
-            });
+            singleton.AddAnalysisTech(techTypeToBeAnalysed, techTypesToUnlock, UnlockMessage, UnlockSound, UnlockSprite);
         }
 
         /// <summary>

--- a/SMLHelper/Patchers/KnownTechPatcher.cs
+++ b/SMLHelper/Patchers/KnownTechPatcher.cs
@@ -7,7 +7,7 @@
     internal class KnownTechPatcher
     {
         internal static List<TechType> UnlockedAtStart = new List<TechType>();
-        internal static List<KnownTech.AnalysisTech> AnalysisTech = new List<KnownTech.AnalysisTech>();
+        internal static IDictionary<TechType, KnownTech.AnalysisTech> AnalysisTech = new SelfCheckingDictionary<TechType, KnownTech.AnalysisTech>("AnalysisTech");
 
         private static bool initialized = false;
 
@@ -30,14 +30,14 @@
             // Direct access to private fields made possible by https://github.com/CabbageCrow/AssemblyPublicizer/
             // See README.md for details.
             List<KnownTech.AnalysisTech> analysisTech = KnownTech.analysisTech;
-            IEnumerable<KnownTech.AnalysisTech> techToAdd = AnalysisTech.Where(a => !analysisTech.Any(a2 => a.techType == a2.techType));
+            IEnumerable<KnownTech.AnalysisTech> techToAdd = AnalysisTech.Values.Where(a => !analysisTech.Any(a2 => a.techType == a2.techType));
 
             foreach (KnownTech.AnalysisTech tech in analysisTech)
             {
                 if (tech.unlockSound != null && tech.techType == TechType.BloodOil)
                     UnlockSound = tech.unlockSound;
 
-                foreach (KnownTech.AnalysisTech customTech in AnalysisTech)
+                foreach (KnownTech.AnalysisTech customTech in AnalysisTech.Values)
                 {
                     if (tech.techType == customTech.techType)
                     {

--- a/SMLHelper/Patchers/LanguagePatcher.cs
+++ b/SMLHelper/Patchers/LanguagePatcher.cs
@@ -4,6 +4,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Reflection;
     using System.Text;
 
     internal class LanguagePatcher


### PR DESCRIPTION
 For all calls into SetAnalysisTechEntry,  
the AnalysisTech collection will be checked to see if there already an extra for the techtype to be analyzed.
This should clean things up when multiple mods attach unlocks for the same item.